### PR TITLE
Add reusable EJS partials for standardized design language

### DIFF
--- a/src/partials/blockquote.ejs
+++ b/src/partials/blockquote.ejs
@@ -1,0 +1,29 @@
+<%
+  // Renders a <blockquote> with an attributed citation link.
+  // Consolidates the quote + cite + blockLink pattern repeated across ~14 posts.
+  //
+  // locals:
+  //   quote      — the quoted text. May contain HTML (rendered raw).
+  //   citation   — visible text for the cite link (e.g. 'Wikipedia.org').
+  //   href       — URL for the citation link.
+  //   wrap       — 'container' (default) | 'content' | 'none'. Outer wrapper kind.
+  //   wrapClass  — extra classes on the outer wrapper.
+  //
+  // Usage:
+  //   partial('blockquote', { ...locals,
+  //     quote: 'A self-operating machine.',
+  //     citation: 'Wikipedia.org',
+  //     href: 'https://en.wikipedia.org/wiki/Automaton',
+  //   })
+  const wrap = locals.wrap || 'container';
+  const wrapClass = [wrap !== 'none' ? wrap : '', locals.wrapClass || '']
+    .filter(Boolean).join(' ');
+%>
+<% if (wrap !== 'none') { %><div class="<%- wrapClass %>"><% } %>
+<blockquote>
+  <p><%- locals.quote %></p>
+  <% if (locals.citation && locals.href) { %>
+    <cite><%- blockLink(locals.citation, { href: locals.href }) %></cite>
+  <% } %>
+</blockquote>
+<% if (wrap !== 'none') { %></div><% } %>

--- a/src/partials/canvas-demo.ejs
+++ b/src/partials/canvas-demo.ejs
@@ -1,0 +1,40 @@
+<%
+  // Renders a canvas demo container with optional play/pause button.
+  // Consolidates the pattern used across canvas-based posts (polyrhythm,
+  // 2d-automaton, lissajous-curve, cellular-automaton, etc.).
+  //
+  // locals:
+  //   canvasId     — id for the <canvas>. Default 'canvas'.
+  //   canvasClass  — extra classes on the <canvas>.
+  //   canvasAttrs  — raw attribute string on the <canvas> (e.g. 'width="800" height="600"').
+  //   playId       — id for the start/play button. Default 'play'.
+  //   playLabel    — button text. Default 'Start'.
+  //   showPlay     — set to false to omit the play button. Default true.
+  //   wrap         — 'section' (default) | 'content' | 'none'. Outer wrapper.
+  //                  'section' renders <section><div class="content">.
+  //                  'content' renders just <div class="content">.
+  //                  'none' renders only the canvas-container.
+  //   ariaLabel    — aria-label on the <canvas> for screen readers.
+  //
+  // Usage:
+  //   partial('canvas-demo', { ...locals })
+  //   partial('canvas-demo', { ...locals, canvasId: 'rhythm', playLabel: 'Play rhythm' })
+  const canvasId = locals.canvasId || 'canvas';
+  const playId = locals.playId || 'play';
+  const playLabel = locals.playLabel || 'Start';
+  const showPlay = locals.showPlay !== false;
+  const wrap = locals.wrap || 'section';
+  const canvasClass = locals.canvasClass ? ` class="${locals.canvasClass}"` : '';
+  const canvasAttrs = locals.canvasAttrs ? ` ${locals.canvasAttrs}` : '';
+  const ariaLabel = locals.ariaLabel ? ` aria-label="${locals.ariaLabel}"` : '';
+%>
+<% if (wrap === 'section') { %><section><div class="content"><% } %>
+<% if (wrap === 'content') { %><div class="content"><% } %>
+  <div class="canvas-container">
+    <% if (showPlay) { %>
+      <button id="<%- playId %>" class="button" type="button"><%- playLabel %></button>
+    <% } %>
+    <canvas id="<%- canvasId %>"<%- canvasClass %><%- canvasAttrs %><%- ariaLabel %>></canvas>
+  </div>
+<% if (wrap === 'content') { %></div><% } %>
+<% if (wrap === 'section') { %></div></section><% } %>

--- a/src/partials/form/checkbox.ejs
+++ b/src/partials/form/checkbox.ejs
@@ -1,0 +1,36 @@
+<%
+  // Renders a checkbox with adjacent label.
+  //
+  // Parameter names avoid colliding with site-wide keys via the `...locals`
+  // spread. Use `inputName` instead of `name`.
+  //
+  // locals:
+  //   id         — checkbox id (required). Used as `name` if `inputName` not given.
+  //   label      — visible label text (right of the checkbox).
+  //   inputName  — checkbox `name` attribute. Defaults to id.
+  //   value      — submitted value. Defaults to 'on'.
+  //   checked    — initial checked state.
+  //   disabled   — boolean attribute.
+  //   inputClass, fieldClass — extra classes.
+  //
+  // Usage:
+  //   partial('form/checkbox', { ...locals,
+  //     id: 'random-start', label: 'Random start', checked: false,
+  //   })
+  if (!locals.id) throw new Error('form/checkbox is missing required `id`');
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', 'field--checkbox', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const inputClass = locals.inputClass ? ` class="${locals.inputClass}"` : '';
+  const attrs = [
+    `id="${locals.id}"`,
+    'type="checkbox"',
+    `name="${inputName}"`,
+    locals.value !== undefined ? `value="${locals.value}"` : '',
+    locals.checked ? 'checked' : '',
+    locals.disabled ? 'disabled' : '',
+  ].filter(Boolean).join(' ');
+%>
+<label class="<%- fieldClass %>" for="<%- locals.id %>">
+  <input<%- inputClass %> <%- attrs %> />
+  <% if (locals.label) { %><span class="field-label"><%- locals.label %></span><% } %>
+</label>

--- a/src/partials/form/field.ejs
+++ b/src/partials/form/field.ejs
@@ -1,0 +1,58 @@
+<%
+  // Renders a label + text-like input (text, email, number, search, tel, url, password).
+  // Standardizes label/input association via matching for/id.
+  //
+  // Parameter names avoid colliding with site-wide keys that come along via
+  // the `...locals` spread (e.g. `name`, `description` are reserved by
+  // siteData and front matter). Use `inputName` and `helpText` instead.
+  //
+  // locals:
+  //   id          — input id (required). Also used as `name` if `inputName` not given.
+  //   label       — visible label text. Pass falsy to render no label.
+  //   ariaLabel   — used when no visible label is desired but a11y is still needed.
+  //   type        — input type. Default 'text'.
+  //   inputName   — input `name` attribute. Defaults to id.
+  //   value       — initial value.
+  //   placeholder, min, max, step, maxlength, pattern, autocomplete, inputmode
+  //   required, disabled, readonly, autofocus — boolean attributes.
+  //   inputClass  — extra classes on the <input>.
+  //   fieldClass  — extra classes on the outer wrapper.
+  //   helpText    — optional helper text rendered below the input.
+  //
+  // Usage:
+  //   partial('form/field', { ...locals, id: 'guess', label: 'Your guess', maxlength: 5 })
+  if (!locals.id) throw new Error('form/field is missing required `id`');
+  const type = locals.type || 'text';
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const inputClass = locals.inputClass ? ` class="${locals.inputClass}"` : '';
+  const attrs = [
+    `id="${locals.id}"`,
+    `type="${type}"`,
+    `name="${inputName}"`,
+    locals.value !== undefined ? `value="${locals.value}"` : '',
+    locals.placeholder ? `placeholder="${locals.placeholder}"` : '',
+    locals.min !== undefined ? `min="${locals.min}"` : '',
+    locals.max !== undefined ? `max="${locals.max}"` : '',
+    locals.step !== undefined ? `step="${locals.step}"` : '',
+    locals.maxlength !== undefined ? `maxlength="${locals.maxlength}"` : '',
+    locals.pattern ? `pattern="${locals.pattern}"` : '',
+    locals.autocomplete ? `autocomplete="${locals.autocomplete}"` : '',
+    locals.inputmode ? `inputmode="${locals.inputmode}"` : '',
+    locals.required ? 'required' : '',
+    locals.disabled ? 'disabled' : '',
+    locals.readonly ? 'readonly' : '',
+    locals.autofocus ? 'autofocus' : '',
+    !locals.label && locals.ariaLabel ? `aria-label="${locals.ariaLabel}"` : '',
+    locals.helpText ? `aria-describedby="${locals.id}-desc"` : '',
+  ].filter(Boolean).join(' ');
+%>
+<div class="<%- fieldClass %>">
+  <% if (locals.label) { %>
+    <label for="<%- locals.id %>"><%- locals.label %></label>
+  <% } %>
+  <input<%- inputClass %> <%- attrs %> />
+  <% if (locals.helpText) { %>
+    <span id="<%- locals.id %>-desc" class="field-description"><%- locals.helpText %></span>
+  <% } %>
+</div>

--- a/src/partials/form/radio-group.ejs
+++ b/src/partials/form/radio-group.ejs
@@ -1,0 +1,47 @@
+<%
+  // Renders a fieldset of radio buttons sharing a name.
+  //
+  // Parameter names avoid colliding with site-wide keys via the `...locals`
+  // spread. Use `inputName` instead of `name`.
+  //
+  // locals:
+  //   inputName  — radio group `name` attribute (required). All radios share this.
+  //   legend     — visible <legend> for the group. Pass falsy to omit.
+  //   value      — currently selected value (matches against option.value).
+  //   options    — array of { id?, value, label, disabled? }.
+  //                If `id` is omitted it is derived as `${inputName}-${value}`.
+  //   groupClass — extra classes on the <fieldset>.
+  //   disabled   — disable the whole group.
+  //
+  // Usage:
+  //   partial('form/radio-group', { ...locals,
+  //     inputName: 'difficulty', legend: 'Difficulty', value: 'beginner',
+  //     options: [
+  //       { value: 'beginner', label: 'Beginner' },
+  //       { value: 'intermediate', label: 'Intermediate' },
+  //       { value: 'expert', label: 'Expert' },
+  //     ],
+  //   })
+  if (!locals.inputName) throw new Error('form/radio-group is missing required `inputName`');
+  if (!Array.isArray(locals.options)) throw new Error('form/radio-group requires `options` array');
+  const groupClass = ['field', 'field--radio-group', locals.groupClass || '']
+    .filter(Boolean).join(' ');
+%>
+<fieldset class="<%- groupClass %>"<%- locals.disabled ? ' disabled' : '' %>>
+  <% if (locals.legend) { %><legend><%- locals.legend %></legend><% } %>
+  <% locals.options.forEach((opt) => {
+    const optId = opt.id || `${locals.inputName}-${opt.value}`;
+    const checked = locals.value !== undefined && String(opt.value) === String(locals.value);
+  %>
+    <label class="field--radio" for="<%- optId %>">
+      <input
+        id="<%- optId %>"
+        type="radio"
+        name="<%- locals.inputName %>"
+        value="<%- opt.value %>"
+        <%- checked ? 'checked' : '' %>
+        <%- (opt.disabled || locals.disabled) ? 'disabled' : '' %> />
+      <span class="field-label"><%- opt.label %></span>
+    </label>
+  <% }); %>
+</fieldset>

--- a/src/partials/form/range.ejs
+++ b/src/partials/form/range.ejs
@@ -1,0 +1,54 @@
+<%
+  // Renders a label + range slider with an optional current-value readout.
+  // The value readout has id `${id}-value`; pair with a JS handler that updates
+  // its textContent on the slider's `input` event.
+  //
+  // Parameter names avoid colliding with site-wide keys via the `...locals`
+  // spread. Use `inputName` instead of `name`.
+  //
+  // locals:
+  //   id         — range id (required). Used as `name` if `inputName` not given.
+  //   label      — visible label text.
+  //   ariaLabel  — used when no visible label is desired.
+  //   inputName  — range `name` attribute. Defaults to id.
+  //   min, max, step, value — slider bounds + initial value.
+  //   showValue  — boolean. If true (default), render a <output> element
+  //                next to the slider with id `${id}-value`.
+  //   unit       — optional unit string appended to the value readout (e.g. 'Hz', 'ms').
+  //   disabled   — boolean attribute on the slider.
+  //   inputClass, fieldClass — extra classes.
+  //
+  // Usage:
+  //   partial('form/range', { ...locals,
+  //     id: 'frequency', label: 'Frequency', min: 20, max: 2000, value: 440, unit: 'Hz',
+  //   })
+  if (!locals.id) throw new Error('form/range is missing required `id`');
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', 'field--range', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const inputClass = locals.inputClass ? ` class="${locals.inputClass}"` : '';
+  const showValue = locals.showValue !== false;
+  const min = locals.min !== undefined ? locals.min : 0;
+  const max = locals.max !== undefined ? locals.max : 100;
+  const value = locals.value !== undefined ? locals.value : Math.round((min + max) / 2);
+  const step = locals.step !== undefined ? locals.step : 1;
+  const attrs = [
+    `id="${locals.id}"`,
+    'type="range"',
+    `name="${inputName}"`,
+    `min="${min}"`,
+    `max="${max}"`,
+    `step="${step}"`,
+    `value="${value}"`,
+    locals.disabled ? 'disabled' : '',
+    !locals.label && locals.ariaLabel ? `aria-label="${locals.ariaLabel}"` : '',
+  ].filter(Boolean).join(' ');
+%>
+<div class="<%- fieldClass %>">
+  <% if (locals.label) { %>
+    <label for="<%- locals.id %>"><%- locals.label %></label>
+  <% } %>
+  <input<%- inputClass %> <%- attrs %> />
+  <% if (showValue) { %>
+    <output for="<%- locals.id %>" id="<%- locals.id %>-value"><%- value %><%- locals.unit ? ` ${locals.unit}` : '' %></output>
+  <% } %>
+</div>

--- a/src/partials/form/select.ejs
+++ b/src/partials/form/select.ejs
@@ -1,0 +1,55 @@
+<%
+  // Renders a label + <select> dropdown.
+  //
+  // Parameter names avoid colliding with site-wide keys that come via the
+  // `...locals` spread. Use `inputName` and `helpText` instead of `name`
+  // and `description`.
+  //
+  // locals:
+  //   id         — select id (required). Also used as `name` if `inputName` not given.
+  //   label      — visible label text. Pass falsy to render no label.
+  //   ariaLabel  — used when no visible label is desired.
+  //   inputName  — select `name` attribute. Defaults to id.
+  //   value      — currently selected value (matches against option.value).
+  //   options    — array of { value, label, disabled? }.
+  //                If an option matches `value`, it is rendered with `selected`.
+  //   disabled, required — boolean attributes on the <select>.
+  //   selectClass — extra classes on the <select>.
+  //   fieldClass  — extra classes on the outer wrapper.
+  //   helpText    — optional helper text below the select.
+  //
+  // Usage:
+  //   partial('form/select', { ...locals,
+  //     id: 'rating', label: 'Rating', value: '10',
+  //     options: [
+  //       { value: '10', label: '10 stars' },
+  //       { value: '9',  label: '9 stars' },
+  //     ],
+  //   })
+  if (!locals.id) throw new Error('form/select is missing required `id`');
+  if (!Array.isArray(locals.options)) throw new Error('form/select requires `options` array');
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const selectClass = locals.selectClass ? ` class="${locals.selectClass}"` : '';
+  const selAttrs = [
+    `id="${locals.id}"`,
+    `name="${inputName}"`,
+    locals.disabled ? 'disabled' : '',
+    locals.required ? 'required' : '',
+    !locals.label && locals.ariaLabel ? `aria-label="${locals.ariaLabel}"` : '',
+    locals.helpText ? `aria-describedby="${locals.id}-desc"` : '',
+  ].filter(Boolean).join(' ');
+%>
+<div class="<%- fieldClass %>">
+  <% if (locals.label) { %>
+    <label for="<%- locals.id %>"><%- locals.label %></label>
+  <% } %>
+  <select<%- selectClass %> <%- selAttrs %>>
+    <% locals.options.forEach((opt) => { %>
+      <option value="<%- opt.value %>"<%- opt.disabled ? ' disabled' : '' %><%- (locals.value !== undefined && String(opt.value) === String(locals.value)) ? ' selected' : '' %>><%- opt.label %></option>
+    <% }); %>
+  </select>
+  <% if (locals.helpText) { %>
+    <span id="<%- locals.id %>-desc" class="field-description"><%- locals.helpText %></span>
+  <% } %>
+</div>

--- a/src/partials/page-intro.ejs
+++ b/src/partials/page-intro.ejs
@@ -1,0 +1,26 @@
+<%
+  // Renders a page-introduction paragraph block. Matches the markup currently
+  // hard-coded in layout/base.ejs so the same styling applies.
+  //
+  // Not yet integrated into base.ejs; callable directly from any page that
+  // wants the same look without using the layout's automatic injection.
+  //
+  // locals:
+  //   description — the intro paragraph text (may contain HTML).
+  //   classes     — extra classes appended to .content.description.
+  //   level       — if set, wraps description in <h2>/<hN> instead of <p>.
+  //
+  // Usage:
+  //   partial('page-intro', { ...locals, description: 'A short summary.' })
+  const classes = ['content', 'description', locals.classes || '']
+    .filter(Boolean).join(' ');
+%>
+<div class="<%- classes %>" itemprop="description">
+  <% if (locals.level) {
+       const level = Math.max(2, Math.min(6, locals.level));
+  %>
+    <h<%- level %>><%- locals.description %></h<%- level %>>
+  <% } else { %>
+    <p><%- locals.description %></p>
+  <% } %>
+</div>

--- a/src/partials/results.ejs
+++ b/src/partials/results.ejs
@@ -1,0 +1,36 @@
+<%
+  // Renders a results display section: heading + count readout + output container.
+  // Consolidates the pattern from wordle-solver, imdb-ratings, and similar
+  // solver/calculator pages.
+  //
+  // locals:
+  //   title           — section heading. Default 'Results'.
+  //   level           — heading level (2-6). Default 2.
+  //   countId         — id for the count <span>. Default 'results-count'.
+  //   countLabel      — label preceding the count. Default 'Results:'.
+  //   initialCount    — initial count text. Default '-'.
+  //   containerId     — id for the output container. Default 'results'.
+  //   containerTag    — tag name for the output container. Default 'div'.
+  //   containerClass  — class on the output container. Default 'p'.
+  //   sectionClass    — extra classes on <section>.
+  //   loadingText     — optional placeholder shown inside the container until populated.
+  //
+  // Usage:
+  //   partial('results', { ...locals,
+  //     title: 'Potential Solutions', containerId: 'options',
+  //   })
+  const level = Math.max(2, Math.min(6, locals.level || 2));
+  const title = locals.title || 'Results';
+  const countId = locals.countId || 'results-count';
+  const countLabel = locals.countLabel || 'Results:';
+  const initialCount = locals.initialCount !== undefined ? locals.initialCount : '-';
+  const containerId = locals.containerId || 'results';
+  const containerTag = locals.containerTag || 'div';
+  const containerClass = locals.containerClass || 'p';
+  const sectionClass = ['content', locals.sectionClass || ''].filter(Boolean).join(' ');
+%>
+<section class="<%- sectionClass %>">
+  <h<%- level %>><%- noWidows(title) %></h<%- level %>>
+  <p><%- countLabel %> <span id="<%- countId %>" aria-live="polite"><%- initialCount %></span></p>
+  <<%- containerTag %> class="<%- containerClass %>" id="<%- containerId %>"><% if (locals.loadingText) { %><%- locals.loadingText %><% } %></<%- containerTag %>>
+</section>

--- a/src/partials/section/close.ejs
+++ b/src/partials/section/close.ejs
@@ -1,0 +1,10 @@
+<%
+  // Closes a <section> opened by section/open.
+  // locals:
+  //   kind — must match the value passed to section/open. Default 'content'.
+  const kind = locals.kind || 'content';
+%>
+<% if (kind !== 'none') { %>
+  </div>
+<% } %>
+</section>

--- a/src/partials/section/open.ejs
+++ b/src/partials/section/open.ejs
@@ -1,0 +1,35 @@
+<%
+  // Opens a <section> with an optional inner wrapper and heading.
+  // Pair with section/close to wrap arbitrary page content.
+  //
+  // locals:
+  //   kind        — 'content' (default) | 'container' | 'none'
+  //                 'content' / 'container' render the named wrapper div.
+  //                 'none' omits the inner wrapper entirely.
+  //   title       — optional heading text. Runs through noWidows().
+  //   level       — heading level (2-6). Default 2.
+  //   sectionClass — extra classes on <section>.
+  //   sectionId   — id attribute on <section>.
+  //   wrapperClass — extra classes on the inner div.
+  //   attributes  — raw attribute string injected on <section> (e.g. 'itemscope itemtype="..."').
+  //
+  // Usage:
+  //   partial('section/open', { ...locals, title: 'My title' })
+  //     <p>...</p>
+  //   partial('section/close', locals)
+  const kind = locals.kind || 'content';
+  const level = Math.max(2, Math.min(6, locals.level || 2));
+  const sectionAttrs = [
+    locals.sectionId ? `id="${locals.sectionId}"` : '',
+    locals.sectionClass ? `class="${locals.sectionClass}"` : '',
+    locals.attributes || '',
+  ].filter(Boolean).join(' ');
+  const wrapperClass = [kind !== 'none' ? kind : '', locals.wrapperClass || '']
+    .filter(Boolean).join(' ');
+%><section <%- sectionAttrs %>>
+<% if (kind !== 'none') { %>
+  <div class="<%- wrapperClass %>">
+<% } %>
+<% if (locals.title) { %>
+  <h<%- level %>><%- noWidows(locals.title) %></h<%- level %>>
+<% } %>

--- a/src/partials/toast.ejs
+++ b/src/partials/toast.ejs
@@ -1,0 +1,28 @@
+<%
+  // Renders a <toast-notification> element. Matches the existing wordle-solver
+  // markup so its styles (already in posts/wordle-solver.scss) keep working.
+  //
+  // locals:
+  //   id        — optional id attribute.
+  //   icon      — emoji or short string shown before the message. Default '✔️'.
+  //   message   — the toast message text.
+  //   tag       — custom element tag name. Default 'toast-notification'.
+  //   classes   — extra classes on the outer element.
+  //   role      — ARIA role. Default 'status' (polite live region).
+  //
+  // Usage:
+  //   partial('toast', { ...locals, message: 'Copied to clipboard' })
+  const tag = locals.tag || 'toast-notification';
+  const icon = locals.icon !== undefined ? locals.icon : '✔️';
+  const role = locals.role || 'status';
+  const idAttr = locals.id ? ` id="${locals.id}"` : '';
+  const classAttr = locals.classes ? ` class="${locals.classes}"` : '';
+%>
+<<%- tag %><%- idAttr %><%- classAttr %> role="<%- role %>" aria-live="polite">
+  <div class="container">
+    <div class="nbar">
+      <% if (icon) { %><span class="toast-icon" aria-hidden="true"><%- icon %></span><% } %>
+      <span class="toast-message"><%- locals.message %></span>
+    </div>
+  </div>
+</<%- tag %>>

--- a/src/templates/posts/design-system.ejs
+++ b/src/templates/posts/design-system.ejs
@@ -283,3 +283,251 @@ scripts:
     </ul>
   </div>
 </section>
+
+<section class="partials">
+  <div class="container">
+    <h2>Reusable Partials</h2>
+    <p>
+      Standardized markup primitives that live in
+      <code>src/partials/</code>. Call them with
+      <code>partial('name', { ...locals, ...data })</code>. The
+      <code>...locals</code> spread is required so partials inherit the EJS
+      helper functions (<code>noWidows</code>, <code>blockLink</code>, etc.).
+    </p>
+  </div>
+</section>
+
+<%- partial('section/open', { ...locals,
+  title: 'section/open + section/close',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Wraps arbitrary content in a <code>&lt;section&gt;</code> with an inner
+    <code>.content</code> (default) or <code>.container</code> wrapper, plus
+    an optional heading. Pair an opening call with a matching close.
+  </p>
+  <p>
+    Options: <code>kind</code> (<var>content</var> | <var>container</var> |
+    <var>none</var>), <code>title</code>, <code>level</code> (2&ndash;6),
+    <code>sectionId</code>, <code>sectionClass</code>,
+    <code>wrapperClass</code>, <code>attributes</code>.
+  </p>
+  <p>
+    This entire section is rendered by section/open and section/close &mdash;
+    look at the page source to confirm.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('blockquote', { ...locals,
+  quote: 'An automaton (plural: automata or automatons) is a self-operating machine, or a machine or control mechanism designed to automatically follow a predetermined sequence of operations, or respond to predetermined instructions.',
+  citation: 'Wikipedia.org',
+  href: 'https://en.wikipedia.org/wiki/Automaton',
+}) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'blockquote',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    The quoted text above is rendered by the <code>blockquote</code> partial.
+    Consolidates ~14 occurrences across posts that hand-built a
+    <code>&lt;blockquote&gt;</code> with a <code>&lt;cite&gt;</code> wrapping
+    a <code>blockLink</code>.
+  </p>
+  <p>
+    Options: <code>quote</code>, <code>citation</code>, <code>href</code>,
+    <code>wrap</code> (<var>container</var> | <var>content</var> |
+    <var>none</var>), <code>wrapClass</code>.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'canvas-demo',
+  sectionClass: 'partial-demo',
+  kind: 'container',
+}) %>
+  <p>
+    Wraps a <code>&lt;canvas&gt;</code> in the standard
+    <code>.canvas-container</code> with an optional start button.
+    Consolidates the pattern used across canvas posts (polyrhythm, lissajous,
+    cellular automata, etc.).
+  </p>
+  <p>
+    Options: <code>canvasId</code>, <code>canvasClass</code>,
+    <code>canvasAttrs</code>, <code>playId</code>, <code>playLabel</code>,
+    <code>showPlay</code> (boolean), <code>wrap</code> (<var>section</var> |
+    <var>content</var> | <var>none</var>), <code>ariaLabel</code>.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('canvas-demo', { ...locals,
+  canvasId: 'design-system-canvas-demo',
+  playId: 'design-system-canvas-play',
+  playLabel: 'Demo button',
+  canvasAttrs: 'width="600" height="200" style="background: var(--palette--surface-color, rgba(0,0,0,0.05)); display: block; width: 100%;"',
+  ariaLabel: 'Empty canvas demo',
+}) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/field',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Label + text-like <code>&lt;input&gt;</code> (text, number, email,
+    search, tel, url, password). Standardizes label/input association via
+    matching <code>for</code> / <code>id</code>.
+  </p>
+  <%- partial('form/field', { ...locals,
+    id: 'ds-field-text',
+    label: 'Your name',
+    placeholder: 'Brian',
+  }) %>
+  <%- partial('form/field', { ...locals,
+    id: 'ds-field-number',
+    label: 'Rule number from 0 to 65,535',
+    type: 'number',
+    min: 0,
+    max: 65535,
+    value: 10678,
+    step: 2,
+    helpText: 'Numbers ending in binary 10110 produce interesting patterns.',
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/select',
+  sectionClass: 'partial-demo',
+}) %>
+  <%- partial('form/select', { ...locals,
+    id: 'ds-select-rating',
+    label: 'Rating',
+    value: 8,
+    options: [
+      { value: 10, label: '10 stars' },
+      { value: 9, label: '9 stars' },
+      { value: 8, label: '8 stars' },
+      { value: 7, label: '7 stars' },
+      { value: 6, label: '6 stars' },
+    ],
+  }) %>
+  <%- partial('form/select', { ...locals,
+    id: 'ds-select-period',
+    label: 'How far back?',
+    value: '1month',
+    options: [
+      { value: '7day', label: '1 week' },
+      { value: '1month', label: '1 month' },
+      { value: '3month', label: '3 months' },
+      { value: '12month', label: '1 year' },
+      { value: 'overall', label: 'Forever' },
+    ],
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/range',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Range slider with an attached <code>&lt;output&gt;</code> readout. Wire
+    the slider's <code>input</code> event in JS to update the readout's
+    <code>textContent</code>.
+  </p>
+  <%- partial('form/range', { ...locals,
+    id: 'ds-range-frequency',
+    label: 'Frequency',
+    min: 20,
+    max: 2000,
+    value: 440,
+    unit: 'Hz',
+  }) %>
+  <%- partial('form/range', { ...locals,
+    id: 'ds-range-tempo',
+    label: 'Tempo',
+    min: 40,
+    max: 240,
+    value: 120,
+    unit: 'bpm',
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/checkbox',
+  sectionClass: 'partial-demo',
+}) %>
+  <%- partial('form/checkbox', { ...locals,
+    id: 'ds-checkbox-random',
+    label: 'Random start',
+  }) %>
+  <%- partial('form/checkbox', { ...locals,
+    id: 'ds-checkbox-scroll',
+    label: 'Auto-scroll',
+    checked: true,
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/radio-group',
+  sectionClass: 'partial-demo',
+}) %>
+  <%- partial('form/radio-group', { ...locals,
+    inputName: 'ds-radio-difficulty',
+    legend: 'Difficulty',
+    value: 'intermediate',
+    options: [
+      { value: 'beginner', label: 'Beginner' },
+      { value: 'intermediate', label: 'Intermediate' },
+      { value: 'expert', label: 'Expert' },
+    ],
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('results', { ...locals,
+  title: 'results',
+  containerId: 'ds-results',
+  initialCount: 0,
+  loadingText: '<em>Results appear here once submitted.</em>',
+}) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'results (above)',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Standardized heading + count readout + output container. Used by
+    solver/calculator-style posts.
+    Options: <code>title</code>, <code>level</code>, <code>countId</code>,
+    <code>countLabel</code>, <code>initialCount</code>,
+    <code>containerId</code>, <code>containerTag</code>,
+    <code>containerClass</code>, <code>loadingText</code>.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'toast',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Renders a <code>&lt;toast-notification&gt;</code> element matching the
+    existing wordle-solver markup. Style/animate via the post's stylesheet;
+    show/hide via JS by toggling a class.
+  </p>
+  <%- partial('toast', { ...locals,
+    id: 'ds-toast',
+    message: 'Copied to clipboard',
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'page-intro',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Extracts the description block currently hard-coded in
+    <code>layout/base.ejs</code> into a reusable partial. Not yet integrated
+    into the base layout &mdash; available for opt-in use today.
+  </p>
+  <%- partial('page-intro', { ...locals,
+    description: 'A short, evocative summary of the page that sits between the title and the main content.',
+  }) %>
+<%- partial('section/close', { ...locals }) %>


### PR DESCRIPTION
## Summary

Foundation phase of the design-language standardization effort. Introduces 12 reusable EJS partials that consolidate recurring markup patterns across the site. No existing templates are migrated — everything here is additive and opt-in.

## What's added

`src/partials/`

| Partial | Encapsulates |
|---|---|
| `section/open.ejs` + `section/close.ejs` | `<section>` with `.content`/`.container` wrapper + optional heading |
| `blockquote.ejs` | Quote + attributed citation link (~14 hand-built copies across posts) |
| `canvas-demo.ejs` | Canvas container + play button (5+ canvas-based posts) |
| `form/field.ejs` | Text-like input + label (text/number/email/search/tel/url/password) |
| `form/select.ejs` | Select dropdown + label, options array |
| `form/range.ejs` | Range slider + label + live `<output>` readout |
| `form/checkbox.ejs` | Checkbox + adjacent label |
| `form/radio-group.ejs` | Fieldset of radios sharing a name |
| `results.ejs` | Heading + count readout + output container |
| `toast.ejs` | `<toast-notification>` element (matches existing wordle-solver markup) |
| `page-intro.ejs` | Description block extracted from `base.ejs` (not yet wired in) |

The design-system page has a new "Reusable Partials" section that renders a live example of every partial.

## Convention worth knowing

Calling a partial with \`{ ...locals, ...data }\` brings along everything from \`siteData\` and front matter. Any partial parameter sharing a name with \`siteData.name\`, \`siteData.description\`, \`frontMatter.title\`, etc. silently gets clobbered. First build of this work produced every form input with \`name=\"Brian Anders\"\`.

To avoid that, form partials use \`inputName\` and \`helpText\` instead of \`name\` and \`description\`. The \`...locals\` spread is still required so partials can call EJS helpers (\`noWidows\`, \`blockLink\`, etc.).

## Not in this PR

- No changes to existing post templates — partials are opt-in.
- No SCSS changes — partials produce markup the existing styles already handle.
- No \`golden/\` regeneration — visual-diff baselines for design-system will need refreshing in a follow-up "new goldens" commit.

## Test plan

- [x] \`npm run build:golden\` succeeds, no EJS errors.
- [x] \`npm test\` passes (build.test.mjs + golden.test.mjs).
- [x] design-system page renders all 12 partial demos with correct attributes (id, name, for, value, etc.).
- [ ] (Reviewer) \`npm start\` and visually inspect \`/posts/design-system/\` in browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)