### PR TITLE
Migrate 28 templates to use the new partial system

### DIFF
--- a/src/partials/blockquote.ejs
+++ b/src/partials/blockquote.ejs
@@ -1,0 +1,29 @@
+<%
+  // Renders a <blockquote> with an attributed citation link.
+  // Consolidates the quote + cite + blockLink pattern repeated across ~14 posts.
+  //
+  // locals:
+  //   quote      — the quoted text. May contain HTML (rendered raw).
+  //   citation   — visible text for the cite link (e.g. 'Wikipedia.org').
+  //   href       — URL for the citation link.
+  //   wrap       — 'container' (default) | 'content' | 'none'. Outer wrapper kind.
+  //   wrapClass  — extra classes on the outer wrapper.
+  //
+  // Usage:
+  //   partial('blockquote', { ...locals,
+  //     quote: 'A self-operating machine.',
+  //     citation: 'Wikipedia.org',
+  //     href: 'https://en.wikipedia.org/wiki/Automaton',
+  //   })
+  const wrap = locals.wrap || 'container';
+  const wrapClass = [wrap !== 'none' ? wrap : '', locals.wrapClass || '']
+    .filter(Boolean).join(' ');
+%>
+<% if (wrap !== 'none') { %><div class="<%- wrapClass %>"><% } %>
+<blockquote>
+  <p><%- locals.quote %></p>
+  <% if (locals.citation && locals.href) { %>
+    <cite><%- blockLink(locals.citation, { href: locals.href }) %></cite>
+  <% } %>
+</blockquote>
+<% if (wrap !== 'none') { %></div><% } %>

--- a/src/partials/canvas-demo.ejs
+++ b/src/partials/canvas-demo.ejs
@@ -1,0 +1,40 @@
+<%
+  // Renders a canvas demo container with optional play/pause button.
+  // Consolidates the pattern used across canvas-based posts (polyrhythm,
+  // 2d-automaton, lissajous-curve, cellular-automaton, etc.).
+  //
+  // locals:
+  //   canvasId     — id for the <canvas>. Default 'canvas'.
+  //   canvasClass  — extra classes on the <canvas>.
+  //   canvasAttrs  — raw attribute string on the <canvas> (e.g. 'width="800" height="600"').
+  //   playId       — id for the start/play button. Default 'play'.
+  //   playLabel    — button text. Default 'Start'.
+  //   showPlay     — set to false to omit the play button. Default true.
+  //   wrap         — 'section' (default) | 'content' | 'none'. Outer wrapper.
+  //                  'section' renders <section><div class="content">.
+  //                  'content' renders just <div class="content">.
+  //                  'none' renders only the canvas-container.
+  //   ariaLabel    — aria-label on the <canvas> for screen readers.
+  //
+  // Usage:
+  //   partial('canvas-demo', { ...locals })
+  //   partial('canvas-demo', { ...locals, canvasId: 'rhythm', playLabel: 'Play rhythm' })
+  const canvasId = locals.canvasId || 'canvas';
+  const playId = locals.playId || 'play';
+  const playLabel = locals.playLabel || 'Start';
+  const showPlay = locals.showPlay !== false;
+  const wrap = locals.wrap || 'section';
+  const canvasClass = locals.canvasClass ? ` class="${locals.canvasClass}"` : '';
+  const canvasAttrs = locals.canvasAttrs ? ` ${locals.canvasAttrs}` : '';
+  const ariaLabel = locals.ariaLabel ? ` aria-label="${locals.ariaLabel}"` : '';
+%>
+<% if (wrap === 'section') { %><section><div class="content"><% } %>
+<% if (wrap === 'content') { %><div class="content"><% } %>
+  <div class="canvas-container">
+    <% if (showPlay) { %>
+      <button id="<%- playId %>" class="button" type="button"><%- playLabel %></button>
+    <% } %>
+    <canvas id="<%- canvasId %>"<%- canvasClass %><%- canvasAttrs %><%- ariaLabel %>></canvas>
+  </div>
+<% if (wrap === 'content') { %></div><% } %>
+<% if (wrap === 'section') { %></div></section><% } %>

--- a/src/partials/form/checkbox.ejs
+++ b/src/partials/form/checkbox.ejs
@@ -1,0 +1,36 @@
+<%
+  // Renders a checkbox with adjacent label.
+  //
+  // Parameter names avoid colliding with site-wide keys via the `...locals`
+  // spread. Use `inputName` instead of `name`.
+  //
+  // locals:
+  //   id         — checkbox id (required). Used as `name` if `inputName` not given.
+  //   label      — visible label text (right of the checkbox).
+  //   inputName  — checkbox `name` attribute. Defaults to id.
+  //   value      — submitted value. Defaults to 'on'.
+  //   checked    — initial checked state.
+  //   disabled   — boolean attribute.
+  //   inputClass, fieldClass — extra classes.
+  //
+  // Usage:
+  //   partial('form/checkbox', { ...locals,
+  //     id: 'random-start', label: 'Random start', checked: false,
+  //   })
+  if (!locals.id) throw new Error('form/checkbox is missing required `id`');
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', 'field--checkbox', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const inputClass = locals.inputClass ? ` class="${locals.inputClass}"` : '';
+  const attrs = [
+    `id="${locals.id}"`,
+    'type="checkbox"',
+    `name="${inputName}"`,
+    locals.value !== undefined ? `value="${locals.value}"` : '',
+    locals.checked ? 'checked' : '',
+    locals.disabled ? 'disabled' : '',
+  ].filter(Boolean).join(' ');
+%>
+<label class="<%- fieldClass %>" for="<%- locals.id %>">
+  <input<%- inputClass %> <%- attrs %> />
+  <% if (locals.label) { %><span class="field-label"><%- locals.label %></span><% } %>
+</label>

--- a/src/partials/form/field.ejs
+++ b/src/partials/form/field.ejs
@@ -1,0 +1,58 @@
+<%
+  // Renders a label + text-like input (text, email, number, search, tel, url, password).
+  // Standardizes label/input association via matching for/id.
+  //
+  // Parameter names avoid colliding with site-wide keys that come along via
+  // the `...locals` spread (e.g. `name`, `description` are reserved by
+  // siteData and front matter). Use `inputName` and `helpText` instead.
+  //
+  // locals:
+  //   id          — input id (required). Also used as `name` if `inputName` not given.
+  //   label       — visible label text. Pass falsy to render no label.
+  //   ariaLabel   — used when no visible label is desired but a11y is still needed.
+  //   type        — input type. Default 'text'.
+  //   inputName   — input `name` attribute. Defaults to id.
+  //   value       — initial value.
+  //   placeholder, min, max, step, maxlength, pattern, autocomplete, inputmode
+  //   required, disabled, readonly, autofocus — boolean attributes.
+  //   inputClass  — extra classes on the <input>.
+  //   fieldClass  — extra classes on the outer wrapper.
+  //   helpText    — optional helper text rendered below the input.
+  //
+  // Usage:
+  //   partial('form/field', { ...locals, id: 'guess', label: 'Your guess', maxlength: 5 })
+  if (!locals.id) throw new Error('form/field is missing required `id`');
+  const type = locals.type || 'text';
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const inputClass = locals.inputClass ? ` class="${locals.inputClass}"` : '';
+  const attrs = [
+    `id="${locals.id}"`,
+    `type="${type}"`,
+    `name="${inputName}"`,
+    locals.value !== undefined ? `value="${locals.value}"` : '',
+    locals.placeholder ? `placeholder="${locals.placeholder}"` : '',
+    locals.min !== undefined ? `min="${locals.min}"` : '',
+    locals.max !== undefined ? `max="${locals.max}"` : '',
+    locals.step !== undefined ? `step="${locals.step}"` : '',
+    locals.maxlength !== undefined ? `maxlength="${locals.maxlength}"` : '',
+    locals.pattern ? `pattern="${locals.pattern}"` : '',
+    locals.autocomplete ? `autocomplete="${locals.autocomplete}"` : '',
+    locals.inputmode ? `inputmode="${locals.inputmode}"` : '',
+    locals.required ? 'required' : '',
+    locals.disabled ? 'disabled' : '',
+    locals.readonly ? 'readonly' : '',
+    locals.autofocus ? 'autofocus' : '',
+    !locals.label && locals.ariaLabel ? `aria-label="${locals.ariaLabel}"` : '',
+    locals.helpText ? `aria-describedby="${locals.id}-desc"` : '',
+  ].filter(Boolean).join(' ');
+%>
+<div class="<%- fieldClass %>">
+  <% if (locals.label) { %>
+    <label for="<%- locals.id %>"><%- locals.label %></label>
+  <% } %>
+  <input<%- inputClass %> <%- attrs %> />
+  <% if (locals.helpText) { %>
+    <span id="<%- locals.id %>-desc" class="field-description"><%- locals.helpText %></span>
+  <% } %>
+</div>

--- a/src/partials/form/radio-group.ejs
+++ b/src/partials/form/radio-group.ejs
@@ -1,0 +1,47 @@
+<%
+  // Renders a fieldset of radio buttons sharing a name.
+  //
+  // Parameter names avoid colliding with site-wide keys via the `...locals`
+  // spread. Use `inputName` instead of `name`.
+  //
+  // locals:
+  //   inputName  — radio group `name` attribute (required). All radios share this.
+  //   legend     — visible <legend> for the group. Pass falsy to omit.
+  //   value      — currently selected value (matches against option.value).
+  //   options    — array of { id?, value, label, disabled? }.
+  //                If `id` is omitted it is derived as `${inputName}-${value}`.
+  //   groupClass — extra classes on the <fieldset>.
+  //   disabled   — disable the whole group.
+  //
+  // Usage:
+  //   partial('form/radio-group', { ...locals,
+  //     inputName: 'difficulty', legend: 'Difficulty', value: 'beginner',
+  //     options: [
+  //       { value: 'beginner', label: 'Beginner' },
+  //       { value: 'intermediate', label: 'Intermediate' },
+  //       { value: 'expert', label: 'Expert' },
+  //     ],
+  //   })
+  if (!locals.inputName) throw new Error('form/radio-group is missing required `inputName`');
+  if (!Array.isArray(locals.options)) throw new Error('form/radio-group requires `options` array');
+  const groupClass = ['field', 'field--radio-group', locals.groupClass || '']
+    .filter(Boolean).join(' ');
+%>
+<fieldset class="<%- groupClass %>"<%- locals.disabled ? ' disabled' : '' %>>
+  <% if (locals.legend) { %><legend><%- locals.legend %></legend><% } %>
+  <% locals.options.forEach((opt) => {
+    const optId = opt.id || `${locals.inputName}-${opt.value}`;
+    const checked = locals.value !== undefined && String(opt.value) === String(locals.value);
+  %>
+    <label class="field--radio" for="<%- optId %>">
+      <input
+        id="<%- optId %>"
+        type="radio"
+        name="<%- locals.inputName %>"
+        value="<%- opt.value %>"
+        <%- checked ? 'checked' : '' %>
+        <%- (opt.disabled || locals.disabled) ? 'disabled' : '' %> />
+      <span class="field-label"><%- opt.label %></span>
+    </label>
+  <% }); %>
+</fieldset>

--- a/src/partials/form/range.ejs
+++ b/src/partials/form/range.ejs
@@ -1,0 +1,54 @@
+<%
+  // Renders a label + range slider with an optional current-value readout.
+  // The value readout has id `${id}-value`; pair with a JS handler that updates
+  // its textContent on the slider's `input` event.
+  //
+  // Parameter names avoid colliding with site-wide keys via the `...locals`
+  // spread. Use `inputName` instead of `name`.
+  //
+  // locals:
+  //   id         — range id (required). Used as `name` if `inputName` not given.
+  //   label      — visible label text.
+  //   ariaLabel  — used when no visible label is desired.
+  //   inputName  — range `name` attribute. Defaults to id.
+  //   min, max, step, value — slider bounds + initial value.
+  //   showValue  — boolean. If true (default), render a <output> element
+  //                next to the slider with id `${id}-value`.
+  //   unit       — optional unit string appended to the value readout (e.g. 'Hz', 'ms').
+  //   disabled   — boolean attribute on the slider.
+  //   inputClass, fieldClass — extra classes.
+  //
+  // Usage:
+  //   partial('form/range', { ...locals,
+  //     id: 'frequency', label: 'Frequency', min: 20, max: 2000, value: 440, unit: 'Hz',
+  //   })
+  if (!locals.id) throw new Error('form/range is missing required `id`');
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', 'field--range', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const inputClass = locals.inputClass ? ` class="${locals.inputClass}"` : '';
+  const showValue = locals.showValue !== false;
+  const min = locals.min !== undefined ? locals.min : 0;
+  const max = locals.max !== undefined ? locals.max : 100;
+  const value = locals.value !== undefined ? locals.value : Math.round((min + max) / 2);
+  const step = locals.step !== undefined ? locals.step : 1;
+  const attrs = [
+    `id="${locals.id}"`,
+    'type="range"',
+    `name="${inputName}"`,
+    `min="${min}"`,
+    `max="${max}"`,
+    `step="${step}"`,
+    `value="${value}"`,
+    locals.disabled ? 'disabled' : '',
+    !locals.label && locals.ariaLabel ? `aria-label="${locals.ariaLabel}"` : '',
+  ].filter(Boolean).join(' ');
+%>
+<div class="<%- fieldClass %>">
+  <% if (locals.label) { %>
+    <label for="<%- locals.id %>"><%- locals.label %></label>
+  <% } %>
+  <input<%- inputClass %> <%- attrs %> />
+  <% if (showValue) { %>
+    <output for="<%- locals.id %>" id="<%- locals.id %>-value"><%- value %><%- locals.unit ? ` ${locals.unit}` : '' %></output>
+  <% } %>
+</div>

--- a/src/partials/form/select.ejs
+++ b/src/partials/form/select.ejs
@@ -1,0 +1,55 @@
+<%
+  // Renders a label + <select> dropdown.
+  //
+  // Parameter names avoid colliding with site-wide keys that come via the
+  // `...locals` spread. Use `inputName` and `helpText` instead of `name`
+  // and `description`.
+  //
+  // locals:
+  //   id         — select id (required). Also used as `name` if `inputName` not given.
+  //   label      — visible label text. Pass falsy to render no label.
+  //   ariaLabel  — used when no visible label is desired.
+  //   inputName  — select `name` attribute. Defaults to id.
+  //   value      — currently selected value (matches against option.value).
+  //   options    — array of { value, label, disabled? }.
+  //                If an option matches `value`, it is rendered with `selected`.
+  //   disabled, required — boolean attributes on the <select>.
+  //   selectClass — extra classes on the <select>.
+  //   fieldClass  — extra classes on the outer wrapper.
+  //   helpText    — optional helper text below the select.
+  //
+  // Usage:
+  //   partial('form/select', { ...locals,
+  //     id: 'rating', label: 'Rating', value: '10',
+  //     options: [
+  //       { value: '10', label: '10 stars' },
+  //       { value: '9',  label: '9 stars' },
+  //     ],
+  //   })
+  if (!locals.id) throw new Error('form/select is missing required `id`');
+  if (!Array.isArray(locals.options)) throw new Error('form/select requires `options` array');
+  const inputName = locals.inputName || locals.id;
+  const fieldClass = ['field', locals.fieldClass || ''].filter(Boolean).join(' ');
+  const selectClass = locals.selectClass ? ` class="${locals.selectClass}"` : '';
+  const selAttrs = [
+    `id="${locals.id}"`,
+    `name="${inputName}"`,
+    locals.disabled ? 'disabled' : '',
+    locals.required ? 'required' : '',
+    !locals.label && locals.ariaLabel ? `aria-label="${locals.ariaLabel}"` : '',
+    locals.helpText ? `aria-describedby="${locals.id}-desc"` : '',
+  ].filter(Boolean).join(' ');
+%>
+<div class="<%- fieldClass %>">
+  <% if (locals.label) { %>
+    <label for="<%- locals.id %>"><%- locals.label %></label>
+  <% } %>
+  <select<%- selectClass %> <%- selAttrs %>>
+    <% locals.options.forEach((opt) => { %>
+      <option value="<%- opt.value %>"<%- opt.disabled ? ' disabled' : '' %><%- (locals.value !== undefined && String(opt.value) === String(locals.value)) ? ' selected' : '' %>><%- opt.label %></option>
+    <% }); %>
+  </select>
+  <% if (locals.helpText) { %>
+    <span id="<%- locals.id %>-desc" class="field-description"><%- locals.helpText %></span>
+  <% } %>
+</div>

--- a/src/partials/page-intro.ejs
+++ b/src/partials/page-intro.ejs
@@ -1,0 +1,26 @@
+<%
+  // Renders a page-introduction paragraph block. Matches the markup currently
+  // hard-coded in layout/base.ejs so the same styling applies.
+  //
+  // Not yet integrated into base.ejs; callable directly from any page that
+  // wants the same look without using the layout's automatic injection.
+  //
+  // locals:
+  //   description — the intro paragraph text (may contain HTML).
+  //   classes     — extra classes appended to .content.description.
+  //   level       — if set, wraps description in <h2>/<hN> instead of <p>.
+  //
+  // Usage:
+  //   partial('page-intro', { ...locals, description: 'A short summary.' })
+  const classes = ['content', 'description', locals.classes || '']
+    .filter(Boolean).join(' ');
+%>
+<div class="<%- classes %>" itemprop="description">
+  <% if (locals.level) {
+       const level = Math.max(2, Math.min(6, locals.level));
+  %>
+    <h<%- level %>><%- locals.description %></h<%- level %>>
+  <% } else { %>
+    <p><%- locals.description %></p>
+  <% } %>
+</div>

--- a/src/partials/results.ejs
+++ b/src/partials/results.ejs
@@ -1,0 +1,36 @@
+<%
+  // Renders a results display section: heading + count readout + output container.
+  // Consolidates the pattern from wordle-solver, imdb-ratings, and similar
+  // solver/calculator pages.
+  //
+  // locals:
+  //   title           — section heading. Default 'Results'.
+  //   level           — heading level (2-6). Default 2.
+  //   countId         — id for the count <span>. Default 'results-count'.
+  //   countLabel      — label preceding the count. Default 'Results:'.
+  //   initialCount    — initial count text. Default '-'.
+  //   containerId     — id for the output container. Default 'results'.
+  //   containerTag    — tag name for the output container. Default 'div'.
+  //   containerClass  — class on the output container. Default 'p'.
+  //   sectionClass    — extra classes on <section>.
+  //   loadingText     — optional placeholder shown inside the container until populated.
+  //
+  // Usage:
+  //   partial('results', { ...locals,
+  //     title: 'Potential Solutions', containerId: 'options',
+  //   })
+  const level = Math.max(2, Math.min(6, locals.level || 2));
+  const title = locals.title || 'Results';
+  const countId = locals.countId || 'results-count';
+  const countLabel = locals.countLabel || 'Results:';
+  const initialCount = locals.initialCount !== undefined ? locals.initialCount : '-';
+  const containerId = locals.containerId || 'results';
+  const containerTag = locals.containerTag || 'div';
+  const containerClass = locals.containerClass || 'p';
+  const sectionClass = ['content', locals.sectionClass || ''].filter(Boolean).join(' ');
+%>
+<section class="<%- sectionClass %>">
+  <h<%- level %>><%- noWidows(title) %></h<%- level %>>
+  <p><%- countLabel %> <span id="<%- countId %>" aria-live="polite"><%- initialCount %></span></p>
+  <<%- containerTag %> class="<%- containerClass %>" id="<%- containerId %>"><% if (locals.loadingText) { %><%- locals.loadingText %><% } %></<%- containerTag %>>
+</section>

--- a/src/partials/results.ejs
+++ b/src/partials/results.ejs
@@ -3,8 +3,11 @@
   // Consolidates the pattern from wordle-solver, imdb-ratings, and similar
   // solver/calculator pages.
   //
+  // Uses `resultsTitle` (not `title`) to avoid inheriting `frontMatter.title`
+  // via the `...locals` spread.
+  //
   // locals:
-  //   title           — section heading. Default 'Results'.
+  //   resultsTitle    — section heading. Default 'Results'.
   //   level           — heading level (2-6). Default 2.
   //   countId         — id for the count <span>. Default 'results-count'.
   //   countLabel      — label preceding the count. Default 'Results:'.
@@ -17,10 +20,10 @@
   //
   // Usage:
   //   partial('results', { ...locals,
-  //     title: 'Potential Solutions', containerId: 'options',
+  //     resultsTitle: 'Potential Solutions', containerId: 'options',
   //   })
   const level = Math.max(2, Math.min(6, locals.level || 2));
-  const title = locals.title || 'Results';
+  const title = locals.resultsTitle || 'Results';
   const countId = locals.countId || 'results-count';
   const countLabel = locals.countLabel || 'Results:';
   const initialCount = locals.initialCount !== undefined ? locals.initialCount : '-';

--- a/src/partials/section/close.ejs
+++ b/src/partials/section/close.ejs
@@ -1,0 +1,10 @@
+<%
+  // Closes a <section> opened by section/open.
+  // locals:
+  //   kind — must match the value passed to section/open. Default 'content'.
+  const kind = locals.kind || 'content';
+%>
+<% if (kind !== 'none') { %>
+  </div>
+<% } %>
+</section>

--- a/src/partials/section/open.ejs
+++ b/src/partials/section/open.ejs
@@ -2,19 +2,23 @@
   // Opens a <section> with an optional inner wrapper and heading.
   // Pair with section/close to wrap arbitrary page content.
   //
+  // Uses `sectionTitle` (not `title`) for the heading because `title` is set
+  // globally by the page's front matter and would otherwise be inherited via
+  // the `...locals` spread, producing a duplicate heading on every page.
+  //
   // locals:
-  //   kind        — 'content' (default) | 'container' | 'none'
-  //                 'content' / 'container' render the named wrapper div.
-  //                 'none' omits the inner wrapper entirely.
-  //   title       — optional heading text. Runs through noWidows().
-  //   level       — heading level (2-6). Default 2.
+  //   kind         — 'content' (default) | 'container' | 'none'
+  //                  'content' / 'container' render the named wrapper div.
+  //                  'none' omits the inner wrapper entirely.
+  //   sectionTitle — optional heading text. Runs through noWidows().
+  //   level        — heading level (2-6). Default 2.
   //   sectionClass — extra classes on <section>.
-  //   sectionId   — id attribute on <section>.
+  //   sectionId    — id attribute on <section>.
   //   wrapperClass — extra classes on the inner div.
-  //   attributes  — raw attribute string injected on <section> (e.g. 'itemscope itemtype="..."').
+  //   attributes   — raw attribute string injected on <section> (e.g. 'itemscope itemtype="..."').
   //
   // Usage:
-  //   partial('section/open', { ...locals, title: 'My title' })
+  //   partial('section/open', { ...locals, sectionTitle: 'My title' })
   //     <p>...</p>
   //   partial('section/close', locals)
   const kind = locals.kind || 'content';
@@ -30,6 +34,6 @@
 <% if (kind !== 'none') { %>
   <div class="<%- wrapperClass %>">
 <% } %>
-<% if (locals.title) { %>
-  <h<%- level %>><%- noWidows(locals.title) %></h<%- level %>>
+<% if (locals.sectionTitle) { %>
+  <h<%- level %>><%- noWidows(locals.sectionTitle) %></h<%- level %>>
 <% } %>

--- a/src/partials/section/open.ejs
+++ b/src/partials/section/open.ejs
@@ -1,0 +1,35 @@
+<%
+  // Opens a <section> with an optional inner wrapper and heading.
+  // Pair with section/close to wrap arbitrary page content.
+  //
+  // locals:
+  //   kind        — 'content' (default) | 'container' | 'none'
+  //                 'content' / 'container' render the named wrapper div.
+  //                 'none' omits the inner wrapper entirely.
+  //   title       — optional heading text. Runs through noWidows().
+  //   level       — heading level (2-6). Default 2.
+  //   sectionClass — extra classes on <section>.
+  //   sectionId   — id attribute on <section>.
+  //   wrapperClass — extra classes on the inner div.
+  //   attributes  — raw attribute string injected on <section> (e.g. 'itemscope itemtype="..."').
+  //
+  // Usage:
+  //   partial('section/open', { ...locals, title: 'My title' })
+  //     <p>...</p>
+  //   partial('section/close', locals)
+  const kind = locals.kind || 'content';
+  const level = Math.max(2, Math.min(6, locals.level || 2));
+  const sectionAttrs = [
+    locals.sectionId ? `id="${locals.sectionId}"` : '',
+    locals.sectionClass ? `class="${locals.sectionClass}"` : '',
+    locals.attributes || '',
+  ].filter(Boolean).join(' ');
+  const wrapperClass = [kind !== 'none' ? kind : '', locals.wrapperClass || '']
+    .filter(Boolean).join(' ');
+%><section <%- sectionAttrs %>>
+<% if (kind !== 'none') { %>
+  <div class="<%- wrapperClass %>">
+<% } %>
+<% if (locals.title) { %>
+  <h<%- level %>><%- noWidows(locals.title) %></h<%- level %>>
+<% } %>

--- a/src/partials/toast.ejs
+++ b/src/partials/toast.ejs
@@ -1,0 +1,28 @@
+<%
+  // Renders a <toast-notification> element. Matches the existing wordle-solver
+  // markup so its styles (already in posts/wordle-solver.scss) keep working.
+  //
+  // locals:
+  //   id        — optional id attribute.
+  //   icon      — emoji or short string shown before the message. Default '✔️'.
+  //   message   — the toast message text.
+  //   tag       — custom element tag name. Default 'toast-notification'.
+  //   classes   — extra classes on the outer element.
+  //   role      — ARIA role. Default 'status' (polite live region).
+  //
+  // Usage:
+  //   partial('toast', { ...locals, message: 'Copied to clipboard' })
+  const tag = locals.tag || 'toast-notification';
+  const icon = locals.icon !== undefined ? locals.icon : '✔️';
+  const role = locals.role || 'status';
+  const idAttr = locals.id ? ` id="${locals.id}"` : '';
+  const classAttr = locals.classes ? ` class="${locals.classes}"` : '';
+%>
+<<%- tag %><%- idAttr %><%- classAttr %> role="<%- role %>" aria-live="polite">
+  <div class="container">
+    <div class="nbar">
+      <% if (icon) { %><span class="toast-icon" aria-hidden="true"><%- icon %></span><% } %>
+      <span class="toast-message"><%- locals.message %></span>
+    </div>
+  </div>
+</<%- tag %>>

--- a/src/templates/404.html.ejs
+++ b/src/templates/404.html.ejs
@@ -10,10 +10,8 @@ styles:
   - 'main'
 ---
 
-<section>
-  <div class="content">
-    <p>
-      It looks like the page you were trying to reach is not available. It may have been moved, deleted, or the link you followed may be broken. Please navigate to a different part of the website.
-    </p>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    It looks like the page you were trying to reach is not available. It may have been moved, deleted, or the link you followed may be broken. Please navigate to a different part of the website.
+  </p>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/about.ejs
+++ b/src/templates/about.ejs
@@ -12,194 +12,192 @@ scripts:
 ---
 
 
-<section class="contributions">
-  <div class="content deck">
-    <%
-        const model = [
-          {
-            heading: "Podcast & YouTube channel: Bat Lessons",
-            image: "/images/about/contributions/batlessons.webp",
-            copyBlock: `Batman history, presented by ${inlineLink('Alex Cash', { href: 'https://alex.cash', external: true })} and myself. It focuses on the context around the development of the characters, the history of the Batman universe, and the impact that our world had on it.`,
-            links: [
-              {
-                label: "Podcast site",
-                url: locals.batLessons,
-              },
-            ],
-          }, {
-            heading: "YouTube channel: Banders Drums",
-            image: "/images/drums/logo.png",
-            copyBlock: "A YouTube channel with videos of me playing drum covers.",
-            links: [
-              {
-                label: "Main Site",
-                path: locals.bandersDrums.path,
-              }, {
-                label: "YouTube Channel",
-                url: locals.bandersDrums.youtube,
-              },
-            ],
-          }, {
-            heading: "VSCode extension: Sublime Duplicate Text",
-            image: "/images/about/contributions/sublime-duplicate-text-logo.webp",
-            copyBlock: "I built a VSCode extension that duplicates text like Sublime Text does. This makes replicating the keyboard shortcuts in VSCode a bit simpler.",
-            links: [
-              {
-                label: "VSCode Extension Marketplace",
-                url: "https://marketplace.visualstudio.com/items?itemName=brian-anders.sublime-duplicate-text",
-              }, {
-                label: "Github",
-                url: "https://github.com/briananders/sublime-text-dublicate",
-              },
-            ],
-          }, {
-            heading: "NPM package: Pageweight",
-            image: "/images/about/contributions/npm-logo.svg",
-            copyBlock: "A Node.js CLI tool that measures the total weight of a webpage on initial load. It catalogues every asset the browser fetches — scripts, stylesheets, images, fonts, and more — and presents a formatted breakdown grouped by type and sorted by size.",
-            links: [
+<%- partial('section/open', { ...locals, sectionClass: 'contributions', wrapperClass: 'deck' }) %>
+  <%
+      const model = [
+        {
+          heading: "Podcast & YouTube channel: Bat Lessons",
+          image: "/images/about/contributions/batlessons.webp",
+          copyBlock: `Batman history, presented by ${inlineLink('Alex Cash', { href: 'https://alex.cash', external: true })} and myself. It focuses on the context around the development of the characters, the history of the Batman universe, and the impact that our world had on it.`,
+          links: [
             {
-            label: "NPM Package",
-            url: "https://www.npmjs.com/package/@briananders/pageweight",
-            }, {
-            label: "Github",
-            url: "https://github.com/briananders/pageweight",
+              label: "Podcast site",
+              url: locals.batLessons,
             },
-            ],
-            },{
-            heading: "NPM package: Two Way Merge",
-            image: "/images/about/contributions/npm-logo.svg",
-            copyBlock: "A CLI tool that performs a two-way sync between two directories, making both sides mirror each other. It is designed to be run repeatedly — as a cron job, for example — to keep two locations in sync.",
-            links: [
-              {
-                label: "NPM Package",
-                url: "https://www.npmjs.com/package/@briananders/two-way-merge",
-              }, {
-                label: "Github",
-                url: "https://github.com/briananders/two-way-merge",
-              },
-            ],
+          ],
+        }, {
+          heading: "YouTube channel: Banders Drums",
+          image: "/images/drums/logo.png",
+          copyBlock: "A YouTube channel with videos of me playing drum covers.",
+          links: [
+            {
+              label: "Main Site",
+              path: locals.bandersDrums.path,
+            }, {
+              label: "YouTube Channel",
+              url: locals.bandersDrums.youtube,
+            },
+          ],
+        }, {
+          heading: "VSCode extension: Sublime Duplicate Text",
+          image: "/images/about/contributions/sublime-duplicate-text-logo.webp",
+          copyBlock: "I built a VSCode extension that duplicates text like Sublime Text does. This makes replicating the keyboard shortcuts in VSCode a bit simpler.",
+          links: [
+            {
+              label: "VSCode Extension Marketplace",
+              url: "https://marketplace.visualstudio.com/items?itemName=brian-anders.sublime-duplicate-text",
+            }, {
+              label: "Github",
+              url: "https://github.com/briananders/sublime-text-dublicate",
+            },
+          ],
+        }, {
+          heading: "NPM package: Pageweight",
+          image: "/images/about/contributions/npm-logo.svg",
+          copyBlock: "A Node.js CLI tool that measures the total weight of a webpage on initial load. It catalogues every asset the browser fetches — scripts, stylesheets, images, fonts, and more — and presents a formatted breakdown grouped by type and sorted by size.",
+          links: [
+          {
+          label: "NPM Package",
+          url: "https://www.npmjs.com/package/@briananders/pageweight",
           }, {
-            heading: "Ruby Gem: Middleman XML Validator",
-            image: "/images/about/contributions/rubygems-logo.svg",
-            copyBlock: "I built a Ruby Gem and published it to the global library. The gem was an XML validator for Middleman static site generator systems.",
-            links: [
-              {
-                label: "Ruby Gem",
-                url: "https://rubygems.org/gems/middleman-xmlvalidator",
-              }, {
-                label: "Github",
-                url: "https://github.com/briananders/MiddlemanXMLValidator",
-              },
-            ],
-          }, {
-            heading: "Alfred Workflow: Google Meet Code",
-            image: "/images/about/contributions/alfred-logo.png",
-            copyBlock: "I wrote a simple Alfred Workflow to extract the meeting code from a Google Meet URL.",
-            links: [
-              {
-                label: "Alfred App",
-                url: "https://www.alfredapp.com/",
-              }, {
-                label: "Workflow",
-                url: "/downloads/Meet_Code.alfredworkflow",
-              },
-            ],
-          }, {
-            heading: "Speaking: Graceland University ACM Chapter Presentation",
-            image: "/images/about/contributions/graceland-logo.svg",
-            copyBlock: "ACM stands for The Association for Computing Machinery. As a former ACM President of the Graceland University chapter, I try to present at ACM whenever I'm in town. The campus newspaper wrote up a little piece after one of my previous visits.",
-            links: [
-              {
-                label: "Graceland News",
-                url: "https://www.graceland.edu/news/graceland-university-alumnus-brian-anders-shares-real-world-tips-on-campus/",
-              },
-            ],
-          }, {
-            heading: "Podcast Interview: Signed In Ink",
-            image: "/images/about/contributions/signed-in-ink-cover-art.webp",
-            copyBlock: `My brother ${inlineLink('Kevin', { href: 'https://www.instagram.com/kevin_anders/' })} has a podcast about people. People with tattoos. I have been a guest on the show a few times.`,
-            links: [
-              {
-                label: "Oct 12, 2020",
-                url: "https://signedinink.libsyn.com/brian-anders",
-              }, {
-                label: "Dec 14, 2020",
-                url: "https://signedinink.libsyn.com/brian-anders-0",
-              }, {
-                label: "Dec 28, 2020",
-                url: "https://signedinink.libsyn.com/stephanie-brian-anders",
-              }, {
-                label: "Jun 7, 2021",
-                url: "https://signedinink.libsyn.com/brian-anders-1",
-              }, {
-                label: "Nov 9, 2021",
-                url: "https://signedinink.libsyn.com/brian-anders-2",
-              }, {
-                label: "Dec 6, 2021",
-                url: "https://signedinink.libsyn.com/brian-anders-3",
-              },
-            ],
-          }, {
-            heading: "MICS 2013 Robotics contest",
-            image: "/images/about/contributions/lego-logo.svg",
-            copyBlock: `MICS stands for The Midwest Instruction and Computing Symposium. MICS hosts an annual robotics contest and a programming contest. After ${inlineLink('Alex', { href: 'https://alex.cash/Adventures-in-Robotics/' })} graduated, I enhanced the ${inlineLink('code', { href: 'https://github.com/briananders/Robotics-Solutions' })} that we wrote in 2011 to compete in the robotics contest again. I managed to win 2nd place, again.`,
-            links: [
-              {
-                label: "Github",
-                url: "https://github.com/briananders/MICS-Robot-2013",
-              },
-            ],
-          }, {
-            heading: "Fish Tank Computer 2012",
-            image: "/images/about/contributions/youtube-logo.svg",
-            copyBlock: `For a college course, ${inlineLink('Alex Cash', { href: 'https://alex.cash/Adventures-in-Robotics/' })} and I made a fishtank computer using mineral oil. The idea is that the mineral oil will cool the computer. Since mineral oil is non-conductive, the computer components are safe and won't ruin. The downside is that the oil can wick up the cord and into the wall socket. The experiment worked, and was a good learning experience for us.`,
-            links: [
-              {
-                label: "Youtube Video",
-                dataVideoId: 'GNhxvhKoagg',
-              },
-            ],
-          }, {
-            heading: "MICS 2011 Robotics contest",
-            image: "/images/about/contributions/lego-logo.svg",
-            copyBlock: `MICS stands for The Midwest Instruction and Computing Symposium. MICS hosts an annual robotics contest and a programming contest. This is the code that ${inlineLink('Alex Cash', { href: 'https://alex.cash/Adventures-in-Robotics/' })} and I wrote to compete in the robotics contest. We won 2nd place.`,
-            links: [
-              {
-                label: "Github",
-                url: "https://github.com/briananders/Robotics-Solutions",
-              },
-            ],
-          }, {
-            heading: "iTunes JScripts",
-            image: "/images/about/contributions/itunes-logo.svg",
-            copyBlock: "I have been a junkie for iTunes and Apple Music since middle school. For many of my early years, I was a Windows user. My parents wouldn't let me have internet, so I manually managed my library. This means that I typed in everything by hand. When I learned to program, I realized how helpful it would be to automate some library management tasks. I wrote JScripts to interface with my iTunes Library and to do repetitive tasks.",
-            links: [
-              {
-                label: "Github",
-                url: "https://github.com/briananders/iTunes-JavaScript-JScript",
-              },
-            ]
-          }, {
-            heading: "Participated in RAGBRAI 2017",
-            image: "/images/about/contributions/ragbrai-logo.svg",
-            copyBlock: "RAGBRAI stands for The Register’s Annual Great Bike Ride Across Iowa. In 2017, my mom and I rode RAGBRAI together. We joined the Graceland University alumni team for the week. We rode over 400 miles in 7 days.",
-            links: [
-              {
-                label: "Media link",
-                url: "https://graceland.meritpages.com/news/corrected--graceland-university-participates-in-ragbrai-2017-for-a-seventh-year-/816/",
-              }, {
-                label: "RAGBRAI site",
-                url: "https://ragbrai.com/",
-              }, {
-                label: "2017 RAGBRAI Archive",
-                url: "https://ragbrai.com/category/2017-ragbrai/",
-              },
-            ]
-          }
-        ]
-        model.forEach(({ copyBlock, image, heading, links }) => {
-      %>
-    <%- partial('contributions-card', Object.assign(locals, { copyBlock, image, heading, links })); %>
-    <% }); %>
-  </div>
-</section>
+          label: "Github",
+          url: "https://github.com/briananders/pageweight",
+          },
+          ],
+          },{
+          heading: "NPM package: Two Way Merge",
+          image: "/images/about/contributions/npm-logo.svg",
+          copyBlock: "A CLI tool that performs a two-way sync between two directories, making both sides mirror each other. It is designed to be run repeatedly — as a cron job, for example — to keep two locations in sync.",
+          links: [
+            {
+              label: "NPM Package",
+              url: "https://www.npmjs.com/package/@briananders/two-way-merge",
+            }, {
+              label: "Github",
+              url: "https://github.com/briananders/two-way-merge",
+            },
+          ],
+        }, {
+          heading: "Ruby Gem: Middleman XML Validator",
+          image: "/images/about/contributions/rubygems-logo.svg",
+          copyBlock: "I built a Ruby Gem and published it to the global library. The gem was an XML validator for Middleman static site generator systems.",
+          links: [
+            {
+              label: "Ruby Gem",
+              url: "https://rubygems.org/gems/middleman-xmlvalidator",
+            }, {
+              label: "Github",
+              url: "https://github.com/briananders/MiddlemanXMLValidator",
+            },
+          ],
+        }, {
+          heading: "Alfred Workflow: Google Meet Code",
+          image: "/images/about/contributions/alfred-logo.png",
+          copyBlock: "I wrote a simple Alfred Workflow to extract the meeting code from a Google Meet URL.",
+          links: [
+            {
+              label: "Alfred App",
+              url: "https://www.alfredapp.com/",
+            }, {
+              label: "Workflow",
+              url: "/downloads/Meet_Code.alfredworkflow",
+            },
+          ],
+        }, {
+          heading: "Speaking: Graceland University ACM Chapter Presentation",
+          image: "/images/about/contributions/graceland-logo.svg",
+          copyBlock: "ACM stands for The Association for Computing Machinery. As a former ACM President of the Graceland University chapter, I try to present at ACM whenever I'm in town. The campus newspaper wrote up a little piece after one of my previous visits.",
+          links: [
+            {
+              label: "Graceland News",
+              url: "https://www.graceland.edu/news/graceland-university-alumnus-brian-anders-shares-real-world-tips-on-campus/",
+            },
+          ],
+        }, {
+          heading: "Podcast Interview: Signed In Ink",
+          image: "/images/about/contributions/signed-in-ink-cover-art.webp",
+          copyBlock: `My brother ${inlineLink('Kevin', { href: 'https://www.instagram.com/kevin_anders/' })} has a podcast about people. People with tattoos. I have been a guest on the show a few times.`,
+          links: [
+            {
+              label: "Oct 12, 2020",
+              url: "https://signedinink.libsyn.com/brian-anders",
+            }, {
+              label: "Dec 14, 2020",
+              url: "https://signedinink.libsyn.com/brian-anders-0",
+            }, {
+              label: "Dec 28, 2020",
+              url: "https://signedinink.libsyn.com/stephanie-brian-anders",
+            }, {
+              label: "Jun 7, 2021",
+              url: "https://signedinink.libsyn.com/brian-anders-1",
+            }, {
+              label: "Nov 9, 2021",
+              url: "https://signedinink.libsyn.com/brian-anders-2",
+            }, {
+              label: "Dec 6, 2021",
+              url: "https://signedinink.libsyn.com/brian-anders-3",
+            },
+          ],
+        }, {
+          heading: "MICS 2013 Robotics contest",
+          image: "/images/about/contributions/lego-logo.svg",
+          copyBlock: `MICS stands for The Midwest Instruction and Computing Symposium. MICS hosts an annual robotics contest and a programming contest. After ${inlineLink('Alex', { href: 'https://alex.cash/Adventures-in-Robotics/' })} graduated, I enhanced the ${inlineLink('code', { href: 'https://github.com/briananders/Robotics-Solutions' })} that we wrote in 2011 to compete in the robotics contest again. I managed to win 2nd place, again.`,
+          links: [
+            {
+              label: "Github",
+              url: "https://github.com/briananders/MICS-Robot-2013",
+            },
+          ],
+        }, {
+          heading: "Fish Tank Computer 2012",
+          image: "/images/about/contributions/youtube-logo.svg",
+          copyBlock: `For a college course, ${inlineLink('Alex Cash', { href: 'https://alex.cash/Adventures-in-Robotics/' })} and I made a fishtank computer using mineral oil. The idea is that the mineral oil will cool the computer. Since mineral oil is non-conductive, the computer components are safe and won't ruin. The downside is that the oil can wick up the cord and into the wall socket. The experiment worked, and was a good learning experience for us.`,
+          links: [
+            {
+              label: "Youtube Video",
+              dataVideoId: 'GNhxvhKoagg',
+            },
+          ],
+        }, {
+          heading: "MICS 2011 Robotics contest",
+          image: "/images/about/contributions/lego-logo.svg",
+          copyBlock: `MICS stands for The Midwest Instruction and Computing Symposium. MICS hosts an annual robotics contest and a programming contest. This is the code that ${inlineLink('Alex Cash', { href: 'https://alex.cash/Adventures-in-Robotics/' })} and I wrote to compete in the robotics contest. We won 2nd place.`,
+          links: [
+            {
+              label: "Github",
+              url: "https://github.com/briananders/Robotics-Solutions",
+            },
+          ],
+        }, {
+          heading: "iTunes JScripts",
+          image: "/images/about/contributions/itunes-logo.svg",
+          copyBlock: "I have been a junkie for iTunes and Apple Music since middle school. For many of my early years, I was a Windows user. My parents wouldn't let me have internet, so I manually managed my library. This means that I typed in everything by hand. When I learned to program, I realized how helpful it would be to automate some library management tasks. I wrote JScripts to interface with my iTunes Library and to do repetitive tasks.",
+          links: [
+            {
+              label: "Github",
+              url: "https://github.com/briananders/iTunes-JavaScript-JScript",
+            },
+          ]
+        }, {
+          heading: "Participated in RAGBRAI 2017",
+          image: "/images/about/contributions/ragbrai-logo.svg",
+          copyBlock: "RAGBRAI stands for The Register’s Annual Great Bike Ride Across Iowa. In 2017, my mom and I rode RAGBRAI together. We joined the Graceland University alumni team for the week. We rode over 400 miles in 7 days.",
+          links: [
+            {
+              label: "Media link",
+              url: "https://graceland.meritpages.com/news/corrected--graceland-university-participates-in-ragbrai-2017-for-a-seventh-year-/816/",
+            }, {
+              label: "RAGBRAI site",
+              url: "https://ragbrai.com/",
+            }, {
+              label: "2017 RAGBRAI Archive",
+              url: "https://ragbrai.com/category/2017-ragbrai/",
+            },
+          ]
+        }
+      ]
+      model.forEach(({ copyBlock, image, heading, links }) => {
+    %>
+  <%- partial('contributions-card', Object.assign(locals, { copyBlock, image, heading, links })); %>
+  <% }); %>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/drums.ejs
+++ b/src/templates/drums.ejs
@@ -24,16 +24,14 @@ scripts:
   }); %>
 </div>
 
-<section>
-  <div class="container">
-    <p>
-      Banders Drums is my channel for drum covers. I grew up loving all kinds of rock and punk music. When I was younger, I played in symphonic band, jazz band, and the orchestra. Over time, I have focused more and more time and energy on playing to the music that I love listening to.
-    </p>
-    <p>
-      Hardcore and emo bands like Emery and Underoath are my favorite to play to. I also play lots of music that features Travis Barker. Someday, I will write my own music, but for now I will continue posting drum cover videos.
-    </p>
-  </div>
-</section>
+<%- partial('section/open', { ...locals, kind: 'container' }) %>
+  <p>
+    Banders Drums is my channel for drum covers. I grew up loving all kinds of rock and punk music. When I was younger, I played in symphonic band, jazz band, and the orchestra. Over time, I have focused more and more time and energy on playing to the music that I love listening to.
+  </p>
+  <p>
+    Hardcore and emo bands like Emery and Underoath are my favorite to play to. I also play lots of music that features Travis Barker. Someday, I will write my own music, but for now I will continue posting drum cover videos.
+  </p>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>
 
 <section>
   <header class="container">

--- a/src/templates/index.html.ejs
+++ b/src/templates/index.html.ejs
@@ -18,7 +18,7 @@ scripts:
 <%- partial('head/styles', { ...locals, path: 'homepage', inlineStyles: true }) %>
 
 
-<section class="contributions">
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'contributions' }) %>
   <div class="content deck">
     <%
       const model = [
@@ -61,7 +61,7 @@ scripts:
       href: '/about/',
     }); %>
   </div>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>
 
 
   <section class="posts">

--- a/src/templates/posts/2d-automaton.ejs
+++ b/src/templates/posts/2d-automaton.ejs
@@ -14,16 +14,11 @@ scripts:
 - 'posts/2d-automaton'
 ---
 
-<div class="container">
-  <blockquote>
-    <p>An automaton (plural: automata or automatons) is a self-operating machine, or a machine or control mechanism
-      designed to automatically follow a predetermined sequence of operations, or respond to predetermined instructions.
-    </p>
-    <cite>
-      <%- blockLink("Wikipedia.org", { href: 'https://en.wikipedia.org/wiki/Automaton' }); %>
-    </cite>
-  </blockquote>
-</div>
+<%- partial('blockquote', { ...locals,
+  quote: 'An automaton (plural: automata or automatons) is a self-operating machine, or a machine or control mechanism\n      designed to automatically follow a predetermined sequence of operations, or respond to predetermined instructions.\n    ',
+  citation: 'Wikipedia.org',
+  href: 'https://en.wikipedia.org/wiki/Automaton',
+}) %>
 
 <div class="content">
 
@@ -94,8 +89,6 @@ scripts:
   </form>
 </div>
 
-<section>
-  <div class="content">
-    <canvas id="canvas"></canvas>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <canvas id="canvas"></canvas>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/ant-life-simulator.ejs
+++ b/src/templates/posts/ant-life-simulator.ejs
@@ -14,7 +14,7 @@ scripts:
 - 'posts/ant-life-simulator/index'
 ---
 
-<section class="content">
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'content' }) %>
   <ol>
     <li>50 ants (white)</li>
     <li>20 anteaters (green)</li>
@@ -25,7 +25,7 @@ scripts:
     <li>If an anteater goes without eating for 12 turns, it will starve.</li>
     <li>Ants move first</li>
   </ol>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>
 
 <div class="content">
   <div id="board">
@@ -38,7 +38,7 @@ scripts:
   </div>
 </div>
 
-<section class="content">
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'content' }) %>
   <div class="score-bar">
     <span id="ants-bar"></span>
     <span id="ant-eaters-bar"></span>
@@ -51,4 +51,4 @@ scripts:
     <li>Anteaters Eaten: <span id="ant-eaters-eaten">0</span></li>
     <li>Anteaters Starved: <span id="ant-eaters-killed">0</span></li>
   </ul>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>

--- a/src/templates/posts/blue-green.ejs
+++ b/src/templates/posts/blue-green.ejs
@@ -15,19 +15,17 @@ scripts:
 - 'posts/blue-green'
 ---
 
-<section>
-  <div class="content">
-    <p>Is this more blue or more green?</p>
+<%- partial('section/open', { ...locals }) %>
+  <p>Is this more blue or more green?</p>
 
-    <div id=canvas class=canvas></div>
+  <div id=canvas class=canvas></div>
 
-    <div class="buttons p">
-      <button id=blue-button>More blue</button>
-      <button id=green-button>More green</button>
-      <button id=submit>I'm unsure</button>
-    </div>
+  <div class="buttons p">
+    <button id=blue-button>More blue</button>
+    <button id=green-button>More green</button>
+    <button id=submit>I'm unsure</button>
   </div>
-</section>
+<%- partial('section/close', { ...locals }) %>
 
 <div class="content">
   <div class=reveal style="display: none;">

--- a/src/templates/posts/canvas-static.ejs
+++ b/src/templates/posts/canvas-static.ejs
@@ -13,15 +13,11 @@ scripts:
   - 'posts/canvas-static'
 ---
 
-<section>
-  <div class="content">
-    <canvas id="canvas"></canvas>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <canvas id="canvas"></canvas>
+<%- partial('section/close', { ...locals }) %>
 
-<section>
-  <div class="container">
-    <div id="graph">
-    </div>
+<%- partial('section/open', { ...locals, kind: 'container' }) %>
+  <div id="graph">
   </div>
-</section>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>

--- a/src/templates/posts/cellular-automaton.ejs
+++ b/src/templates/posts/cellular-automaton.ejs
@@ -15,16 +15,11 @@ scripts:
 - 'posts/cellular-automaton'
 ---
 
-<div class="container">
-  <blockquote>
-    <p>An automaton (plural: automata or automatons) is a self-operating machine, or a machine or control mechanism
-      designed to automatically follow a predetermined sequence of operations, or respond to predetermined instructions.
-    </p>
-    <cite>
-      <%- blockLink("Wikipedia.org", { href: 'https://en.wikipedia.org/wiki/Automaton' }); %>
-    </cite>
-  </blockquote>
-</div>
+<%- partial('blockquote', { ...locals,
+  quote: 'An automaton (plural: automata or automatons) is a self-operating machine, or a machine or control mechanism\n      designed to automatically follow a predetermined sequence of operations, or respond to predetermined instructions.\n    ',
+  citation: 'Wikipedia.org',
+  href: 'https://en.wikipedia.org/wiki/Automaton',
+}) %>
 
 <div class="content">
   <p>
@@ -123,6 +118,4 @@ scripts:
   </form>
 </div>
 
-<section>
-  <div class="container"><canvas id="canvas"></canvas></div>
-</section>
+<%- partial('section/open', { ...locals, kind: 'container' }) %><canvas id="canvas"></canvas><%- partial('section/close', { ...locals, kind: 'container' }) %>

--- a/src/templates/posts/coin-flip.ejs
+++ b/src/templates/posts/coin-flip.ejs
@@ -13,44 +13,42 @@ scripts:
 - 'posts/coin-flip'
 ---
 
-<section>
-  <div class="content">
-    <p>
-      Sometimes you just need to flip a coin to make a decision. This simple widget lets you flip a virtual coin with a satisfying animation and keeps track of your results.
-    </p>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    Sometimes you just need to flip a coin to make a decision. This simple widget lets you flip a virtual coin with a satisfying animation and keeps track of your results.
+  </p>
 
-    <div class="coin-container card">
-      <div class="coin-wrapper">
-        <div id="coin" class="coin">
-          <div class="coin-side heads">
-            <div class="coin-face">HEADS</div>
-          </div>
-          <div class="coin-side tails">
-            <div class="coin-face">TAILS</div>
-          </div>
+  <div class="coin-container card">
+    <div class="coin-wrapper">
+      <div id="coin" class="coin">
+        <div class="coin-side heads">
+          <div class="coin-face">HEADS</div>
+        </div>
+        <div class="coin-side tails">
+          <div class="coin-face">TAILS</div>
         </div>
       </div>
-
-      <div class="result" id="result">Click "Flip Coin" to start</div>
-
-      <button type="button" id="flip-button" class="button">Flip Coin</button>
-
-      <div class="stats">
-        <div class="stat-item">
-          <span class="stat-label">Heads:</span>
-          <span class="stat-value" id="heads-count">0</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Tails:</span>
-          <span class="stat-value" id="tails-count">0</span>
-        </div>
-        <div class="stat-item">
-          <span class="stat-label">Total Flips:</span>
-          <span class="stat-value" id="total-count">0</span>
-        </div>
-      </div>
-
-      <button type="button" id="reset-button" class="button-secondary">Reset Stats</button>
     </div>
+
+    <div class="result" id="result">Click "Flip Coin" to start</div>
+
+    <button type="button" id="flip-button" class="button">Flip Coin</button>
+
+    <div class="stats">
+      <div class="stat-item">
+        <span class="stat-label">Heads:</span>
+        <span class="stat-value" id="heads-count">0</span>
+      </div>
+      <div class="stat-item">
+        <span class="stat-label">Tails:</span>
+        <span class="stat-value" id="tails-count">0</span>
+      </div>
+      <div class="stat-item">
+        <span class="stat-label">Total Flips:</span>
+        <span class="stat-value" id="total-count">0</span>
+      </div>
+    </div>
+
+    <button type="button" id="reset-button" class="button-secondary">Reset Stats</button>
   </div>
-</section>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/color-canvas.ejs
+++ b/src/templates/posts/color-canvas.ejs
@@ -11,24 +11,20 @@ scripts:
   - 'posts/color-canvas'
 ---
 
-<section>
-  <div class="content">
-    <p>
-      The X-axis represents red. The Y-axis represents green. The slider represents the Z-axis, which is blue. Just slide the slider, below, and appreciate all of the beautiful colors that your screen can render!
-    </p>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    The X-axis represents red. The Y-axis represents green. The slider represents the Z-axis, which is blue. Just slide the slider, below, and appreciate all of the beautiful colors that your screen can render!
+  </p>
+<%- partial('section/close', { ...locals }) %>
 
-<section>
-  <div class="content">
-    <canvas id="canvas"></canvas>
+<%- partial('section/open', { ...locals }) %>
+  <canvas id="canvas"></canvas>
 
-    <div class="form">
-      <button id="play-pause">
-        <%- img({ src: '/images/icons/play.svg', classes: ['play'] }); %>
-        <%- img({ src: '/images/icons/pause.svg', classes: ['pause'] }); %>
-      </button>
-      <input id='blue-slider' type="range" min="0" max="255" value="0" step="1" aria-label="Blue value">
-    </div>
+  <div class="form">
+    <button id="play-pause">
+      <%- img({ src: '/images/icons/play.svg', classes: ['play'] }); %>
+      <%- img({ src: '/images/icons/pause.svg', classes: ['pause'] }); %>
+    </button>
+    <input id='blue-slider' type="range" min="0" max="255" value="0" step="1" aria-label="Blue value">
   </div>
-</section>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/design-system.ejs
+++ b/src/templates/posts/design-system.ejs
@@ -283,3 +283,251 @@ scripts:
     </ul>
   </div>
 </section>
+
+<section class="partials">
+  <div class="container">
+    <h2>Reusable Partials</h2>
+    <p>
+      Standardized markup primitives that live in
+      <code>src/partials/</code>. Call them with
+      <code>partial('name', { ...locals, ...data })</code>. The
+      <code>...locals</code> spread is required so partials inherit the EJS
+      helper functions (<code>noWidows</code>, <code>blockLink</code>, etc.).
+    </p>
+  </div>
+</section>
+
+<%- partial('section/open', { ...locals,
+  title: 'section/open + section/close',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Wraps arbitrary content in a <code>&lt;section&gt;</code> with an inner
+    <code>.content</code> (default) or <code>.container</code> wrapper, plus
+    an optional heading. Pair an opening call with a matching close.
+  </p>
+  <p>
+    Options: <code>kind</code> (<var>content</var> | <var>container</var> |
+    <var>none</var>), <code>title</code>, <code>level</code> (2&ndash;6),
+    <code>sectionId</code>, <code>sectionClass</code>,
+    <code>wrapperClass</code>, <code>attributes</code>.
+  </p>
+  <p>
+    This entire section is rendered by section/open and section/close &mdash;
+    look at the page source to confirm.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('blockquote', { ...locals,
+  quote: 'An automaton (plural: automata or automatons) is a self-operating machine, or a machine or control mechanism designed to automatically follow a predetermined sequence of operations, or respond to predetermined instructions.',
+  citation: 'Wikipedia.org',
+  href: 'https://en.wikipedia.org/wiki/Automaton',
+}) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'blockquote',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    The quoted text above is rendered by the <code>blockquote</code> partial.
+    Consolidates ~14 occurrences across posts that hand-built a
+    <code>&lt;blockquote&gt;</code> with a <code>&lt;cite&gt;</code> wrapping
+    a <code>blockLink</code>.
+  </p>
+  <p>
+    Options: <code>quote</code>, <code>citation</code>, <code>href</code>,
+    <code>wrap</code> (<var>container</var> | <var>content</var> |
+    <var>none</var>), <code>wrapClass</code>.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'canvas-demo',
+  sectionClass: 'partial-demo',
+  kind: 'container',
+}) %>
+  <p>
+    Wraps a <code>&lt;canvas&gt;</code> in the standard
+    <code>.canvas-container</code> with an optional start button.
+    Consolidates the pattern used across canvas posts (polyrhythm, lissajous,
+    cellular automata, etc.).
+  </p>
+  <p>
+    Options: <code>canvasId</code>, <code>canvasClass</code>,
+    <code>canvasAttrs</code>, <code>playId</code>, <code>playLabel</code>,
+    <code>showPlay</code> (boolean), <code>wrap</code> (<var>section</var> |
+    <var>content</var> | <var>none</var>), <code>ariaLabel</code>.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('canvas-demo', { ...locals,
+  canvasId: 'design-system-canvas-demo',
+  playId: 'design-system-canvas-play',
+  playLabel: 'Demo button',
+  canvasAttrs: 'width="600" height="200" style="background: var(--palette--surface-color, rgba(0,0,0,0.05)); display: block; width: 100%;"',
+  ariaLabel: 'Empty canvas demo',
+}) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/field',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Label + text-like <code>&lt;input&gt;</code> (text, number, email,
+    search, tel, url, password). Standardizes label/input association via
+    matching <code>for</code> / <code>id</code>.
+  </p>
+  <%- partial('form/field', { ...locals,
+    id: 'ds-field-text',
+    label: 'Your name',
+    placeholder: 'Brian',
+  }) %>
+  <%- partial('form/field', { ...locals,
+    id: 'ds-field-number',
+    label: 'Rule number from 0 to 65,535',
+    type: 'number',
+    min: 0,
+    max: 65535,
+    value: 10678,
+    step: 2,
+    helpText: 'Numbers ending in binary 10110 produce interesting patterns.',
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/select',
+  sectionClass: 'partial-demo',
+}) %>
+  <%- partial('form/select', { ...locals,
+    id: 'ds-select-rating',
+    label: 'Rating',
+    value: 8,
+    options: [
+      { value: 10, label: '10 stars' },
+      { value: 9, label: '9 stars' },
+      { value: 8, label: '8 stars' },
+      { value: 7, label: '7 stars' },
+      { value: 6, label: '6 stars' },
+    ],
+  }) %>
+  <%- partial('form/select', { ...locals,
+    id: 'ds-select-period',
+    label: 'How far back?',
+    value: '1month',
+    options: [
+      { value: '7day', label: '1 week' },
+      { value: '1month', label: '1 month' },
+      { value: '3month', label: '3 months' },
+      { value: '12month', label: '1 year' },
+      { value: 'overall', label: 'Forever' },
+    ],
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/range',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Range slider with an attached <code>&lt;output&gt;</code> readout. Wire
+    the slider's <code>input</code> event in JS to update the readout's
+    <code>textContent</code>.
+  </p>
+  <%- partial('form/range', { ...locals,
+    id: 'ds-range-frequency',
+    label: 'Frequency',
+    min: 20,
+    max: 2000,
+    value: 440,
+    unit: 'Hz',
+  }) %>
+  <%- partial('form/range', { ...locals,
+    id: 'ds-range-tempo',
+    label: 'Tempo',
+    min: 40,
+    max: 240,
+    value: 120,
+    unit: 'bpm',
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/checkbox',
+  sectionClass: 'partial-demo',
+}) %>
+  <%- partial('form/checkbox', { ...locals,
+    id: 'ds-checkbox-random',
+    label: 'Random start',
+  }) %>
+  <%- partial('form/checkbox', { ...locals,
+    id: 'ds-checkbox-scroll',
+    label: 'Auto-scroll',
+    checked: true,
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'form/radio-group',
+  sectionClass: 'partial-demo',
+}) %>
+  <%- partial('form/radio-group', { ...locals,
+    inputName: 'ds-radio-difficulty',
+    legend: 'Difficulty',
+    value: 'intermediate',
+    options: [
+      { value: 'beginner', label: 'Beginner' },
+      { value: 'intermediate', label: 'Intermediate' },
+      { value: 'expert', label: 'Expert' },
+    ],
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('results', { ...locals,
+  title: 'results',
+  containerId: 'ds-results',
+  initialCount: 0,
+  loadingText: '<em>Results appear here once submitted.</em>',
+}) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'results (above)',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Standardized heading + count readout + output container. Used by
+    solver/calculator-style posts.
+    Options: <code>title</code>, <code>level</code>, <code>countId</code>,
+    <code>countLabel</code>, <code>initialCount</code>,
+    <code>containerId</code>, <code>containerTag</code>,
+    <code>containerClass</code>, <code>loadingText</code>.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'toast',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Renders a <code>&lt;toast-notification&gt;</code> element matching the
+    existing wordle-solver markup. Style/animate via the post's stylesheet;
+    show/hide via JS by toggling a class.
+  </p>
+  <%- partial('toast', { ...locals,
+    id: 'ds-toast',
+    message: 'Copied to clipboard',
+  }) %>
+<%- partial('section/close', { ...locals }) %>
+
+<%- partial('section/open', { ...locals,
+  title: 'page-intro',
+  sectionClass: 'partial-demo',
+}) %>
+  <p>
+    Extracts the description block currently hard-coded in
+    <code>layout/base.ejs</code> into a reusable partial. Not yet integrated
+    into the base layout &mdash; available for opt-in use today.
+  </p>
+  <%- partial('page-intro', { ...locals,
+    description: 'A short, evocative summary of the page that sits between the title and the main content.',
+  }) %>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/design-system.ejs
+++ b/src/templates/posts/design-system.ejs
@@ -298,7 +298,7 @@ scripts:
 </section>
 
 <%- partial('section/open', { ...locals,
-  title: 'section/open + section/close',
+  sectionTitle: 'section/open + section/close',
   sectionClass: 'partial-demo',
 }) %>
   <p>
@@ -325,7 +325,7 @@ scripts:
 }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'blockquote',
+  sectionTitle: 'blockquote',
   sectionClass: 'partial-demo',
 }) %>
   <p>
@@ -342,7 +342,7 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'canvas-demo',
+  sectionTitle: 'canvas-demo',
   sectionClass: 'partial-demo',
   kind: 'container',
 }) %>
@@ -369,7 +369,7 @@ scripts:
 }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'form/field',
+  sectionTitle: 'form/field',
   sectionClass: 'partial-demo',
 }) %>
   <p>
@@ -395,7 +395,7 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'form/select',
+  sectionTitle: 'form/select',
   sectionClass: 'partial-demo',
 }) %>
   <%- partial('form/select', { ...locals,
@@ -425,7 +425,7 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'form/range',
+  sectionTitle: 'form/range',
   sectionClass: 'partial-demo',
 }) %>
   <p>
@@ -452,7 +452,7 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'form/checkbox',
+  sectionTitle: 'form/checkbox',
   sectionClass: 'partial-demo',
 }) %>
   <%- partial('form/checkbox', { ...locals,
@@ -467,7 +467,7 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'form/radio-group',
+  sectionTitle: 'form/radio-group',
   sectionClass: 'partial-demo',
 }) %>
   <%- partial('form/radio-group', { ...locals,
@@ -483,14 +483,14 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('results', { ...locals,
-  title: 'results',
+  resultsTitle: 'results',
   containerId: 'ds-results',
   initialCount: 0,
   loadingText: '<em>Results appear here once submitted.</em>',
 }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'results (above)',
+  sectionTitle: 'results (above)',
   sectionClass: 'partial-demo',
 }) %>
   <p>
@@ -504,7 +504,7 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'toast',
+  sectionTitle: 'toast',
   sectionClass: 'partial-demo',
 }) %>
   <p>
@@ -519,7 +519,7 @@ scripts:
 <%- partial('section/close', { ...locals }) %>
 
 <%- partial('section/open', { ...locals,
-  title: 'page-intro',
+  sectionTitle: 'page-intro',
   sectionClass: 'partial-demo',
 }) %>
   <p>

--- a/src/templates/posts/earth-rotating-sprite-animation.ejs
+++ b/src/templates/posts/earth-rotating-sprite-animation.ejs
@@ -12,97 +12,80 @@ scripts:
 - 'posts/earth-rotating-sprite-animation'
 ---
 
-<section>
-  <div class="content">
-    <p>
-      The setup is pretty basic. I have an event listener on document scroll. Using that event I can see how far you
-      have scrolled (<var>window.scrollY</var>). I add that number to an existing counter. Sprinkle on some math (below)
-      and you have the current frame. Easy peasy.
-    </p>
-    <p>
-      The sprite that I'm using has 16 rows and 16 columns. So I had to add in the math for wrapping around from
-      position <var>0, 15</var> to <var>1, 0</var>. That’s why I use <var>$sprite-height</var> and
-      <var>$frame-height</var> below.
-    </p>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    The setup is pretty basic. I have an event listener on document scroll. Using that event I can see how far you
+    have scrolled (<var>window.scrollY</var>). I add that number to an existing counter. Sprinkle on some math (below)
+    and you have the current frame. Easy peasy.
+  </p>
+  <p>
+    The sprite that I'm using has 16 rows and 16 columns. So I had to add in the math for wrapping around from
+    position <var>0, 15</var> to <var>1, 0</var>. That’s why I use <var>$sprite-height</var> and
+    <var>$frame-height</var> below.
+  </p>
+<%- partial('section/close', { ...locals }) %>
+
+
+<%- partial('section/open', { ...locals, sectionTitle: 'Demo' }) %>
+  <div class="p">
+    <div lazy
+      style="--background-image: url('/images/posts/earth-rotating-sprite-animation/earth-sprite-color.webp');"
+      data-lazy-style="background-image: var(--background-image);" id="frame-container" data-number="0"></div>
   </div>
-</section>
+<%- partial('section/close', { ...locals }) %>
 
 
-<section>
-  <div class="content">
-    <h2>
-      Demo
-    </h2>
-    <div class="p">
-      <div lazy
-        style="--background-image: url('/images/posts/earth-rotating-sprite-animation/earth-sprite-color.webp');"
-        data-lazy-style="background-image: var(--background-image);" id="frame-container" data-number="0"></div>
-    </div>
-  </div>
-</section>
+<%- partial('section/open', { ...locals, sectionTitle: 'SASS' }) %>
+  <ul class="p">
+    <li>
+      <b>Width of sprite image:</b>
+      <var>$sprite-width</var>
+    </li>
+    <li>
+      <b>Height of sprite image:</b>
+      <var>$sprite-height</var>
+    </li>
+    <li>
+      <b>Number of horizontal frames:</b>
+      <var>$x-max</var>
+    </li>
+    <li>
+      <b>Number of vertical frames:</b>
+      <var>$y-max</var>
+    </li>
+    <li>
+      <b>Frame width:</b>
+      <var>$frame-width = $sprite-width / $x-max</var>
+    </li>
+    <li>
+      <b>Frame height:</b>
+      <var>$frame-height = $sprite-height / $y-max</var>
+    </li>
+  </ul>
+  <%- code(`#frame-container { width: round($frame-width); height: round($frame-height); background-image:
+    url(/path/to/sprite.jpg); @for $frame from 0 to ($y-max * $x-max) { &[data-number="#{$frame}" ] { $x-position: 1 -
+    round(($frame % $x-max) * $frame-width); $y-position: 1 - round(floor($frame / $x-max) * $frame-height);
+    background-position: #{$x-position} #{$y-position}; } } }`); %>
+<%- partial('section/close', { ...locals }) %>
 
 
-<section>
-  <div class="content">
-    <h2>
-      SASS
-    </h2>
-    <ul class="p">
-      <li>
-        <b>Width of sprite image:</b>
-        <var>$sprite-width</var>
-      </li>
-      <li>
-        <b>Height of sprite image:</b>
-        <var>$sprite-height</var>
-      </li>
-      <li>
-        <b>Number of horizontal frames:</b>
-        <var>$x-max</var>
-      </li>
-      <li>
-        <b>Number of vertical frames:</b>
-        <var>$y-max</var>
-      </li>
-      <li>
-        <b>Frame width:</b>
-        <var>$frame-width = $sprite-width / $x-max</var>
-      </li>
-      <li>
-        <b>Frame height:</b>
-        <var>$frame-height = $sprite-height / $y-max</var>
-      </li>
-    </ul>
-    <%- code(`#frame-container { width: round($frame-width); height: round($frame-height); background-image:
-      url(/path/to/sprite.jpg); @for $frame from 0 to ($y-max * $x-max) { &[data-number="#{$frame}" ] { $x-position: 1 -
-      round(($frame % $x-max) * $frame-width); $y-position: 1 - round(floor($frame / $x-max) * $frame-height);
-      background-position: #{$x-position} #{$y-position}; } } }`); %>
-  </div>
-</section>
+<%- partial('section/open', { ...locals, sectionTitle: 'JavaScript' }) %>
+  <p>
+    There’s almost nothing going on here. Set an event listener on the document for scroll. In the caught event, find
+    the scroll movement using <var>scrollY</var>. Add that to the existing frame number and add a large multiple of
+    <var>numberOfFrames</var> to account for negative numbers (you don’t want a negative frame number). Then, find the
+    modulus of that number to get a final frame number between zero and the maximum number of frames. Finally, set
+    that number to the container’s data attribute, and let the CSS do the rendering work.
+  </p>
+  <%- code( `const frameContainer=document.getElementById('frame-container'); const numberOfFrames=16 * 16; let
+    number=0; let lastKnownScrollPosition=0; function updateEarth(value) { number=((number + value) + (numberOfFrames
+    * 100)) % numberOfFrames; frameContainer.dataset.number=number; } document.addEventListener('scroll', (event)=> {
+    const scrollPosition = Math.floor(window.scrollY);
+    const movementY = scrollPosition - lastKnownScrollPosition;
+    lastKnownScrollPosition = scrollPosition;
 
-
-<section>
-  <div class="content">
-    <h2>
-      JavaScript
-    </h2>
-    <p>
-      There’s almost nothing going on here. Set an event listener on the document for scroll. In the caught event, find
-      the scroll movement using <var>scrollY</var>. Add that to the existing frame number and add a large multiple of
-      <var>numberOfFrames</var> to account for negative numbers (you don’t want a negative frame number). Then, find the
-      modulus of that number to get a final frame number between zero and the maximum number of frames. Finally, set
-      that number to the container’s data attribute, and let the CSS do the rendering work.
-    </p>
-    <%- code( `const frameContainer=document.getElementById('frame-container'); const numberOfFrames=16 * 16; let
-      number=0; let lastKnownScrollPosition=0; function updateEarth(value) { number=((number + value) + (numberOfFrames
-      * 100)) % numberOfFrames; frameContainer.dataset.number=number; } document.addEventListener('scroll', (event)=> {
-      const scrollPosition = Math.floor(window.scrollY);
-      const movementY = scrollPosition - lastKnownScrollPosition;
-      lastKnownScrollPosition = scrollPosition;
-
-      window.requestAnimationFrame(() => {
-      updateEarth(movementY);
-      });
-      });`); %>
-  </div>
-</section>
+    window.requestAnimationFrame(() => {
+    updateEarth(movementY);
+    });
+    });`); %>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/last-fm-scrobbles.ejs
+++ b/src/templates/posts/last-fm-scrobbles.ejs
@@ -35,28 +35,19 @@ scripts:
       <option selected value="all-time">All Time</option>
     </select>
   </div>
-   
+
   <div id="selector-container" class="selector-container"></div>
 </div>
 
-<section>
-  <div class="container">
-    <h2>Artists</h2>
-    <div id="artists"></div>
-  </div>
-</section>
+<%- partial('section/open', { ...locals, kind: 'container', sectionTitle: 'Artists' }) %>
+  <div id="artists"></div>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>
 
-<section>
-  <div class="container">
-    <h2>Albums</h2>
-    <div id="albums"></div>
-  </div>
-</section>
+<%- partial('section/open', { ...locals, kind: 'container', sectionTitle: 'Albums' }) %>
+  <div id="albums"></div>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>
 
-<section>
-  <div class="container">
-    <h2>Yearly Scrobbles</h2>
-    <div id="yearly-scrobbles">
-    </div>
+<%- partial('section/open', { ...locals, kind: 'container', sectionTitle: 'Yearly Scrobbles' }) %>
+  <div id="yearly-scrobbles">
   </div>
-</section>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>

--- a/src/templates/posts/last-fm.ejs
+++ b/src/templates/posts/last-fm.ejs
@@ -16,18 +16,15 @@ scripts:
 - 'posts/last-fm'
 ---
 
-<div class="container">
-  <blockquote>
-    <p>
+<%- partial('blockquote', { ...locals,
+  quote: `
       To 'scrobble' a song means that when you listen to it, the name of the song is sent to a Web site (for example,
       Last.fm) and added to your music profile. Here’s how it works: Once you've signed up and downloaded Last.fm, you
       can scrobble songs you listen to on your computer or iPod automatically.
-    </p>
-    <cite>
-      <%- blockLink('Netlingo.com', { href: "https://www.netlingo.com/word/scrobble.php" })%>
-    </cite>
-  </blockquote>
-</div>
+    `,
+  citation: 'Netlingo.com',
+  href: 'https://www.netlingo.com/word/scrobble.php',
+}) %>
 
 <section>
   <form class="content">
@@ -43,21 +40,19 @@ scripts:
   </form>
 </section>
 
-<section class="content">
-  <h2>Top Albums</h2>
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'content', sectionTitle: 'Top Albums' }) %>
   <link rel="preconnect" href="https://ws.audioscrobbler.com" crossorigin />
   <div class='last-fm-module p' data-type="albums" src="/images/posts/last-fm/default.webp">
     <% for (let i=0; i < 10; i++) { %>
       <%- defaultLastFMModule(); %>
         <% } %>
   </div>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>
 
-<section class="content">
-  <h2>Top Artists</h2>
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'content', sectionTitle: 'Top Artists' }) %>
   <div class='last-fm-module p' data-type="artists">
     <% for (let i=0; i < 10; i++) { %>
       <%- defaultLastFMModule(false); %>
         <% } %>
   </div>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>

--- a/src/templates/posts/minesweeper.ejs
+++ b/src/templates/posts/minesweeper.ejs
@@ -15,8 +15,6 @@ scripts:
 
 
 
-<section>
-  <div class="content">
-    <iframe id="minesweeper-iframe" src="/example/minesweeper"></iframe>
-  </div>
-  </section>
+<%- partial('section/open', { ...locals }) %>
+  <iframe id="minesweeper-iframe" src="/example/minesweeper"></iframe>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/moire-pattern-colors.ejs
+++ b/src/templates/posts/moire-pattern-colors.ejs
@@ -14,17 +14,11 @@ scripts:
 - 'posts/moire-pattern-colors'
 ---
 
-<div class="container">
-  <blockquote>
-    <p>Moiré patterns or moiré fringes are large-scale interference patterns that can be produced when an opaque ruled
-      pattern with transparent gaps is overlaid on another similar pattern. For the moiré interference pattern to
-      appear, the two patterns must not be completely identical, but rather displaced, rotated, or have slightly
-      different pitch.</p>
-    <cite>
-      <%- blockLink("Wikipedia.org", { href: "https://en.wikipedia.org/wiki/Moir%C3%A9_pattern" }); %>
-    </cite>
-  </blockquote>
-</div>
+<%- partial('blockquote', { ...locals,
+  quote: 'Moiré patterns or moiré fringes are large-scale interference patterns that can be produced when an opaque ruled\n      pattern with transparent gaps is overlaid on another similar pattern. For the moiré interference pattern to\n      appear, the two patterns must not be completely identical, but rather displaced, rotated, or have slightly\n      different pitch.',
+  citation: 'Wikipedia.org',
+  href: 'https://en.wikipedia.org/wiki/Moir%C3%A9_pattern',
+}) %>
 
 <div class="container">
   <div class="form" data-controller="red">

--- a/src/templates/posts/moire-patterns.ejs
+++ b/src/templates/posts/moire-patterns.ejs
@@ -14,17 +14,11 @@ scripts:
 - 'posts/moire-patterns'
 ---
 
-<div class="container">
-  <blockquote>
-    <p>Moiré patterns or moiré fringes are large-scale interference patterns that can be produced when an opaque ruled
-      pattern with transparent gaps is overlaid on another similar pattern. For the moiré interference pattern to
-      appear, the two patterns must not be completely identical, but rather displaced, rotated, or have slightly
-      different pitch.</p>
-    <cite>
-      <%- blockLink("Wikipedia.org", { href: "https://en.wikipedia.org/wiki/Moir%C3%A9_pattern" }); %>
-    </cite>
-  </blockquote>
-</div>
+<%- partial('blockquote', { ...locals,
+  quote: 'Moiré patterns or moiré fringes are large-scale interference patterns that can be produced when an opaque ruled\n      pattern with transparent gaps is overlaid on another similar pattern. For the moiré interference pattern to\n      appear, the two patterns must not be completely identical, but rather displaced, rotated, or have slightly\n      different pitch.',
+  citation: 'Wikipedia.org',
+  href: 'https://en.wikipedia.org/wiki/Moir%C3%A9_pattern',
+}) %>
 
 <div class="container">
   <div class="form">

--- a/src/templates/posts/music-news.ejs
+++ b/src/templates/posts/music-news.ejs
@@ -13,24 +13,22 @@ scripts:
 - 'posts/music-news'
 ---
 
-<section>
-  <div class="container">
-    <p id="music-news-meta" class="meta"></p>
-    <div id="music-news-bands-queried-wrap" class="music-news-bands-block" hidden>
-      <h2 class="music-news-bands-heading">Artists searched</h2>
-      <p class="music-news-bands-intro">These names are included when aggregating feeds.</p>
-      <div id="music-news-bands-marquee" class="music-news-bands-marquee"
-        aria-label="Scrolling list of artist names queried for news"></div>
-    </div>
-    <div id="music-news-bands-hits-wrap" class="music-news-bands-block" hidden>
-      <h2 class="music-news-bands-heading">Artists with matching articles</h2>
-      <p class="music-news-bands-intro">Select an artist to filter the list. Select again to show all articles.</p>
-      <div id="music-news-bands-hits" class="music-news-bands-filters" role="group"
-        aria-label="Filter articles by artist"></div>
-    </div>
-    <div id="music-news-list" role="list"></div>
-    <div id="music-news-empty" class="empty" style="display: none;">
-      <p>No matches found at this time.</p>
-    </div>
+<%- partial('section/open', { ...locals, kind: 'container' }) %>
+  <p id="music-news-meta" class="meta"></p>
+  <div id="music-news-bands-queried-wrap" class="music-news-bands-block" hidden>
+    <h2 class="music-news-bands-heading">Artists searched</h2>
+    <p class="music-news-bands-intro">These names are included when aggregating feeds.</p>
+    <div id="music-news-bands-marquee" class="music-news-bands-marquee"
+      aria-label="Scrolling list of artist names queried for news"></div>
   </div>
-</section>
+  <div id="music-news-bands-hits-wrap" class="music-news-bands-block" hidden>
+    <h2 class="music-news-bands-heading">Artists with matching articles</h2>
+    <p class="music-news-bands-intro">Select an artist to filter the list. Select again to show all articles.</p>
+    <div id="music-news-bands-hits" class="music-news-bands-filters" role="group"
+      aria-label="Filter articles by artist"></div>
+  </div>
+  <div id="music-news-list" role="list"></div>
+  <div id="music-news-empty" class="empty" style="display: none;">
+    <p>No matches found at this time.</p>
+  </div>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>

--- a/src/templates/posts/polyrhythm.ejs
+++ b/src/templates/posts/polyrhythm.ejs
@@ -13,25 +13,19 @@ scripts:
   - 'posts/polyrhythm'
 ---
 
-<section>
-  <div class="content">
-    <p>I was perusing YouTube, as one does, and encountered a fascinating channel called <%- inlineLink('Lucid Rhythms', { href: 'https://www.youtube.com/@LucidRhythms' } ) %>. Highly recommend! Through the process of watching their videos, I began to dissect them and attempt to figure out how they work.</p>
+<%- partial('section/open', { ...locals }) %>
+  <p>I was perusing YouTube, as one does, and encountered a fascinating channel called <%- inlineLink('Lucid Rhythms', { href: 'https://www.youtube.com/@LucidRhythms' } ) %>. Highly recommend! Through the process of watching their videos, I began to dissect them and attempt to figure out how they work.</p>
 
-    <blockquote>
-      <p>Polyrhythm is the simultaneous use of two or more rhythms that are not readily perceived as deriving from one another, or as simple manifestations of the same meter.</p>
-      <cite>
-        <%- blockLink("Wikipedia.org", { href: "https://en.wikipedia.org/wiki/Polyrhythm" }); %>
-      </cite>
-    </blockquote>
+  <%- partial('blockquote', { ...locals,
+    wrap: 'none',
+    quote: 'Polyrhythm is the simultaneous use of two or more rhythms that are not readily perceived as deriving from one another, or as simple manifestations of the same meter.',
+    citation: 'Wikipedia.org',
+    href: 'https://en.wikipedia.org/wiki/Polyrhythm',
+  }) %>
 
-    <p>To accomplish this, I used some math to set the velocity of each ball to be a ratio of the other ball velocities. There is a simple mathematical function that sets the velocity. Each ball is assigned a specific tone on the repeating scale of A, C, E, G in different octaves. When the ball touches a wall, the assigned tone plays.</p>
+  <p>To accomplish this, I used some math to set the velocity of each ball to be a ratio of the other ball velocities. There is a simple mathematical function that sets the velocity. Each ball is assigned a specific tone on the repeating scale of A, C, E, G in different octaves. When the ball touches a wall, the assigned tone plays.</p>
 
-    <div class="canvas-container">
-      <button id="play" class="button" >Start</button>
+  <%- partial('canvas-demo', { ...locals, wrap: 'none' }) %>
 
-      <canvas id="canvas"></canvas>
-    </div>
-
-    <debug></debug>
-  </div>
-</section>
+  <debug></debug>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/raining-light-effect.ejs
+++ b/src/templates/posts/raining-light-effect.ejs
@@ -13,8 +13,6 @@ scripts:
   - 'posts/raining-light-effect'
 ---
 
-<section>
-  <div class="content">
-    <canvas id="canvas"></canvas>
-  </div>
-  </section>
+<%- partial('section/open', { ...locals }) %>
+  <canvas id="canvas"></canvas>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/raining-paint.ejs
+++ b/src/templates/posts/raining-paint.ejs
@@ -17,8 +17,6 @@ scripts:
   </label>
 </form>
 
-<section>
-  <div class="content">
-    <canvas id="canvas"></canvas>
-  </div>
-  </section>
+<%- partial('section/open', { ...locals }) %>
+  <canvas id="canvas"></canvas>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/sound-frequency-slider.ejs
+++ b/src/templates/posts/sound-frequency-slider.ejs
@@ -11,22 +11,20 @@ scripts:
   - 'posts/sound-frequency-slider/index'
 ---
 
-<section>
-  <div class="content">
-    <p>
-      Yet, for all my exploration of the digital realm, a particular facet has remained curiously uncharted: the domain of the JavaScript Web Audio API. This omission, despite my deep-rooted enthusiasm for both music and technology, has long piqued my curiosity. This API, I've come to realize, provides a delightful and surprisingly accessible gateway into the captivating universe of sound frequencies and their intricate dance of harmonies and discord.
-    </p>
-    <p>
-      Exploring the JavaScript Web Audio API allows you to embark on a captivating journey into the realm of sound, a realm where you can experiment with frequencies and delve into the mesmerizing interplay of tones. It's a tool that invites you to not only create music but to unlock the secrets of how sound waves interact, and in doing so, enhance your understanding of the auditory world.
-    </p>
-    <p>
-      Moreover, this versatile tool offers a unique opportunity to gauge and evaluate your auditory faculties. Our remarkable human hearing, a remarkable sensory gift, is inherently bounded by a range spanning from the low rumble of 20 Hertz to the high-pitched resonance of 20,000 Hertz. The JavaScript Web Audio API thus becomes a means to test and celebrate the remarkable capabilities of our ears, shedding light on the subtle nuances and subtleties of the auditory experience that often go unnoticed. It's a journey that holds the promise of both discovery and appreciation for the multifaceted world of sound that surrounds us.
-    </p>
-    <p>
-      Experiment and have fun!
-    </p>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    Yet, for all my exploration of the digital realm, a particular facet has remained curiously uncharted: the domain of the JavaScript Web Audio API. This omission, despite my deep-rooted enthusiasm for both music and technology, has long piqued my curiosity. This API, I've come to realize, provides a delightful and surprisingly accessible gateway into the captivating universe of sound frequencies and their intricate dance of harmonies and discord.
+  </p>
+  <p>
+    Exploring the JavaScript Web Audio API allows you to embark on a captivating journey into the realm of sound, a realm where you can experiment with frequencies and delve into the mesmerizing interplay of tones. It's a tool that invites you to not only create music but to unlock the secrets of how sound waves interact, and in doing so, enhance your understanding of the auditory world.
+  </p>
+  <p>
+    Moreover, this versatile tool offers a unique opportunity to gauge and evaluate your auditory faculties. Our remarkable human hearing, a remarkable sensory gift, is inherently bounded by a range spanning from the low rumble of 20 Hertz to the high-pitched resonance of 20,000 Hertz. The JavaScript Web Audio API thus becomes a means to test and celebrate the remarkable capabilities of our ears, shedding light on the subtle nuances and subtleties of the auditory experience that often go unnoticed. It's a journey that holds the promise of both discovery and appreciation for the multifaceted world of sound that surrounds us.
+  </p>
+  <p>
+    Experiment and have fun!
+  </p>
+<%- partial('section/close', { ...locals }) %>
 
 <section>
   <div class="content" id="slider-holder">

--- a/src/templates/posts/sticky-stacky.ejs
+++ b/src/templates/posts/sticky-stacky.ejs
@@ -12,13 +12,11 @@ styles:
   - 'posts/sticky-stacky'
 ---
 
-<section>
-  <div class="content">
-    <p>
-      This is a common design pattern. As I have fixed bugs with many navigation bars, I have reconsidered how complex the setup is. Here, I present a simpler, more general, and scalable way to support such a system.
-    </p>
-  </div>
-  </section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    This is a common design pattern. As I have fixed bugs with many navigation bars, I have reconsidered how complex the setup is. Here, I present a simpler, more general, and scalable way to support such a system.
+  </p>
+<%- partial('section/close', { ...locals }) %>
 
 <div class="sticky-container h3">
   <nav class="sticky-stacky default-styles">
@@ -26,13 +24,11 @@ styles:
   </nav>
 </div>
 
-<section>
-  <div class="content">
-    <p>
-      At its core, this system is not complex. The markup is basic, as is the styles. The javascript can be challenging to wrap your head around, since it has to keep up with the scroll state.
-    </p>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    At its core, this system is not complex. The markup is basic, as is the styles. The javascript can be challenging to wrap your head around, since it has to keep up with the scroll state.
+  </p>
+<%- partial('section/close', { ...locals }) %>
 
 <div class="sticky-container h3">
   <nav class="sticky-stacky default-styles">
@@ -40,17 +36,15 @@ styles:
   </nav>
 </div>
 
-<section>
-  <div class="content">
-    <ol>
-      <li>A container that holds the height and position of the navigation bar on the page.</li>
-      <li>The actual visible navigation bar that sticks when scrolling.</li>
-    </ol>
-    <%- code(`<div class="sticky-container">
+<%- partial('section/open', { ...locals }) %>
+  <ol>
+    <li>A container that holds the height and position of the navigation bar on the page.</li>
+    <li>The actual visible navigation bar that sticks when scrolling.</li>
+  </ol>
+  <%- code(`<div class="sticky-container">
   <div class="sticky-stacky">Sticky Nav Element</div>
 </div>`, { language: 'html' }); %>
-  </div>
-</section>
+<%- partial('section/close', { ...locals }) %>
 
 <div class="sticky-container h3">
   <nav class="sticky-stacky default-styles">
@@ -58,20 +52,18 @@ styles:
   </nav>
 </div>
 
-<section>
-  <div class="content">
-    <p>
-      For the container element, your styles are simple: a block element that holds the height of your navigation bar. Through some experimenting, I found a good way to smooth rendering, and simplify the javascript. We calculate the height and store it in a CSS variable.
-    </p>
-    <p>
-      For the navigation bar itself, the styles are still simple. You need a basic default state, and a fixed state. The default state uses <var>position: relative</var>. The fixed state moves it to <var>position: fixed</var>. The important piece keeps the navigation bars sticking in the right positions.
-    </p>
-    <p>
-      To keep them sticking in the right positions, we depend on two properties. The <var>top</var> property is the sum of the heights of previous navigation bars. Again, I am using a CSS variable for simplicity. The <var>transform</var> property uses another CSS variable to translate the nav bar up and down. This translation handles the peeking logic. The CSS variable we use here will be quite dynamic, and updated with JavaScript.
-    </p>
-    <%- code(getFileContents('/styles/modules/_sticky-stacky.scss'), { language: 'css' }); %>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    For the container element, your styles are simple: a block element that holds the height of your navigation bar. Through some experimenting, I found a good way to smooth rendering, and simplify the javascript. We calculate the height and store it in a CSS variable.
+  </p>
+  <p>
+    For the navigation bar itself, the styles are still simple. You need a basic default state, and a fixed state. The default state uses <var>position: relative</var>. The fixed state moves it to <var>position: fixed</var>. The important piece keeps the navigation bars sticking in the right positions.
+  </p>
+  <p>
+    To keep them sticking in the right positions, we depend on two properties. The <var>top</var> property is the sum of the heights of previous navigation bars. Again, I am using a CSS variable for simplicity. The <var>transform</var> property uses another CSS variable to translate the nav bar up and down. This translation handles the peeking logic. The CSS variable we use here will be quite dynamic, and updated with JavaScript.
+  </p>
+  <%- code(getFileContents('/styles/modules/_sticky-stacky.scss'), { language: 'css' }); %>
+<%- partial('section/close', { ...locals }) %>
 
 <div class="sticky-container h3">
   <nav class="sticky-stacky default-styles">
@@ -79,17 +71,15 @@ styles:
   </nav>
 </div>
 
-<section>
-  <div class="content">
-    <p>
-      Breaking the algorithm into two pieces is the most organized. A class that controls all the sticky navigation bars on the page: StickyController. And a class that updates each sticky navigation bar: StickyStacky.
-    </p>
-    <p>
-      Read through the comments in the JavaScript below. The explanation makes the most sense to me in context.
-    </p>
-    <%- code(getFileContents('/js/_modules/sticky-stacky.js'), { language: 'javascript' }); %>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    Breaking the algorithm into two pieces is the most organized. A class that controls all the sticky navigation bars on the page: StickyController. And a class that updates each sticky navigation bar: StickyStacky.
+  </p>
+  <p>
+    Read through the comments in the JavaScript below. The explanation makes the most sense to me in context.
+  </p>
+  <%- code(getFileContents('/js/_modules/sticky-stacky.js'), { language: 'javascript' }); %>
+<%- partial('section/close', { ...locals }) %>
 
 <div class="sticky-container h3">
   <nav class="sticky-stacky default-styles">
@@ -97,8 +87,6 @@ styles:
   </nav>
 </div>
 
-<section>
-  <div class="content">
-    <p>I hope this has been a helpful and informative way to combine JavaScript, HTML, and CSS in a robust and scalable way. The patterns I use in this solution are more valuable than the solution itself.</p>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>I hope this has been a helpful and informative way to combine JavaScript, HTML, and CSS in a robust and scalable way. The patterns I use in this solution are more valuable than the solution itself.</p>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/unique-stars.ejs
+++ b/src/templates/posts/unique-stars.ejs
@@ -72,8 +72,6 @@ scripts:
 
 </div>
 
-<section>
-  <div class="content">
-    <canvas id='star'></canvas>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <canvas id='star'></canvas>
+<%- partial('section/close', { ...locals }) %>

--- a/src/templates/posts/wordle-solver-2.ejs
+++ b/src/templates/posts/wordle-solver-2.ejs
@@ -13,58 +13,53 @@ scripts:
   - 'posts/wordle-solver-2'
 ---
 
-<section>
-  <div class="container">
-    <p>
-      Let's dive into two key game-changers:
-    </p>
+<%- partial('section/open', { ...locals, kind: 'container' }) %>
+  <p>
+    Let's dive into two key game-changers:
+  </p>
 
-    <h2>
-      Embracing Letter Frequencies:
-    </h2>
-
-    <p>
-      Unveiling the Uneven Alphabet: The 26 letters in the English language aren't evenly distributed across words. Some letters, like S, E, A, R, and O, reign supreme in usage.
-    </p>
-    <p>
-      Harnessing High-Frequency Starters: By strategically choosing your first guess to include these heavy hitters, you can maximize information gain. For instance, "AROSE" covers a whopping 95% of words in the 5-letter dictionary, exponentially increasing your chances of early letter discovery.
-    </p>
-    <p>
-      Adapting to the Narrowing Wordscape: As the game progresses, continue to consider letter frequencies within the remaining possible words. This statistical approach guides you towards guesses that efficiently reveal the hidden word.
-    </p>
-
-    <h2>
-      Delving into the Untapped:
-    </h2>
-
-    <p>
-      Second-Guess Surprises: While logic might suggest choosing a word from the possible solutions list, consider the power of the unexpected. A second guess composed entirely of unused letters can often unveil more letters than a seemingly logical choice.
-    </p>
-    <p>
-      Expanding Your Letter Arsenal: By embracing words like "UNITY" after "AROSE," you cover 100% of letters in the 5-letter dictionary, ensuring a comprehensive exploration of possibilities.
-    </p>
-    <p>
-      Remember: Wordle is a game of both logic and creativity. By understanding letter frequencies and embracing unconventional guesses, you'll unlock a winning strategy that blends statistical prowess with linguistic intuition.
-    </p>
-
-    <h2>
-      Conclusion
-    </h2>
-
-    <p>
-      By integrating these strategies, you'll elevate your Wordle game to new heights, conquering each daily puzzle with confidence and finesse.
-    </p>
-
-    <p>
-      <%- blockLink('Check out the original post', { href: '/posts/wordle-solver/' }) %>
-    </p>
-  </div>
-</section>
-
-<section class="game-board content">
   <h2>
-    Game Board
+    Embracing Letter Frequencies:
   </h2>
+
+  <p>
+    Unveiling the Uneven Alphabet: The 26 letters in the English language aren't evenly distributed across words. Some letters, like S, E, A, R, and O, reign supreme in usage.
+  </p>
+  <p>
+    Harnessing High-Frequency Starters: By strategically choosing your first guess to include these heavy hitters, you can maximize information gain. For instance, "AROSE" covers a whopping 95% of words in the 5-letter dictionary, exponentially increasing your chances of early letter discovery.
+  </p>
+  <p>
+    Adapting to the Narrowing Wordscape: As the game progresses, continue to consider letter frequencies within the remaining possible words. This statistical approach guides you towards guesses that efficiently reveal the hidden word.
+  </p>
+
+  <h2>
+    Delving into the Untapped:
+  </h2>
+
+  <p>
+    Second-Guess Surprises: While logic might suggest choosing a word from the possible solutions list, consider the power of the unexpected. A second guess composed entirely of unused letters can often unveil more letters than a seemingly logical choice.
+  </p>
+  <p>
+    Expanding Your Letter Arsenal: By embracing words like "UNITY" after "AROSE," you cover 100% of letters in the 5-letter dictionary, ensuring a comprehensive exploration of possibilities.
+  </p>
+  <p>
+    Remember: Wordle is a game of both logic and creativity. By understanding letter frequencies and embracing unconventional guesses, you'll unlock a winning strategy that blends statistical prowess with linguistic intuition.
+  </p>
+
+  <h2>
+    Conclusion
+  </h2>
+
+  <p>
+    By integrating these strategies, you'll elevate your Wordle game to new heights, conquering each daily puzzle with confidence and finesse.
+  </p>
+
+  <p>
+    <%- blockLink('Check out the original post', { href: '/posts/wordle-solver/' }) %>
+  </p>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>
+
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'game-board content', sectionTitle: 'Game Board' }) %>
   <p>
     Update the board below so it matches your current game. Mark each letter as a near miss (🟨) or a hit (🟩).
   </p>
@@ -128,31 +123,23 @@ scripts:
     type=button>
     Clear
   </button>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>
 
-<section class="content">
-  <h2>Letter frequency in the dictionary</h2>
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'content', sectionTitle: 'Letter frequency in the dictionary' }) %>
   <div class="p" id="letter-frequency">
   </div>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>
 
-<section class="content">
-  <h2>Suggested Solutions</h2>
-  <p>Results: <span id="results-count">-</span></p>
-  <div class="p" id="options"></div>
-</section>
+<%- partial('results', { ...locals,
+  resultsTitle: 'Suggested Solutions',
+  containerId: 'options',
+}) %>
 
-<section class="content">
-  <h2>Words made of untried letters</h2>
-  <p>Results: <span id="untried-results-count">-</span></p>
-  <div class="p" id="untried-letters">
-  </div>
-</section>
+<%- partial('results', { ...locals,
+  resultsTitle: 'Words made of untried letters',
+  countId: 'untried-results-count',
+  containerId: 'untried-letters',
+  loadingText: '\n  ',
+}) %>
 
-<toast-notification>
-  <div class="container">
-    <div class="nbar">
-      <span>✔️</span> Copied to clipboard
-    </div>
-  </div>
-</toast-notification>
+<%- partial('toast', { ...locals, message: 'Copied to clipboard' }) %>

--- a/src/templates/posts/wordle-solver.ejs
+++ b/src/templates/posts/wordle-solver.ejs
@@ -13,61 +13,52 @@ scripts:
   - 'posts/wordle-solver/index'
 ---
 
-<section>
-  <div class="container">
-    <h2>
-      How to play Wordle
-    </h2>
+<%- partial('section/open', { ...locals, kind: 'container', sectionTitle: 'How to play Wordle' }) %>
+  <p>
+    Wordle is a word game in which players are presented with a grid of letters and must guess a hidden word or phrase.
+  </p>
 
-    <p>
-      Wordle is a word game in which players are presented with a grid of letters and must guess a hidden word or phrase.
-    </p>
+  <p>
+    Here's how to play Wordle:
+  </p>
 
-    <p>
-      Here's how to play Wordle:
-    </p>
+  <ol>
+    <li>
+      A grid of letters will be presented on the screen, with some of the letters already filled in. These letters represent the hidden word or phrase.
+    </li>
+    <li>
+      The player has to guess the hidden word or phrase by typing their guess into the text field provided.
+    </li>
+    <li>
+      The game will indicate how many letters the player has guessed correctly, but not in the correct position, and how many letters are correctly placed.
+    </li>
+    <li>
+      If a letter is correctly placed, that letter will be filled in the grid in the corresponding position.
+    </li>
+    <li>
+      The player can continue guessing different words until they are able to guess the correct one.
+    </li>
+    <li>
+      Some versions of the game have a limited number of guesses, so the player should use them wisely.
+    </li>
+    <li>
+      The game can have different levels and different themes, and some versions may include a time limit.
+    </li>
+    <li>
+      Wordle is a fun and challenging word game that will test your ability to guess words based on the letters provided. Be creative and don't be afraid to try different words and combinations of letters to find the correct answer.
+    </li>
+  </ol>
 
-    <ol>
-      <li>
-        A grid of letters will be presented on the screen, with some of the letters already filled in. These letters represent the hidden word or phrase.
-      </li>
-      <li>
-        The player has to guess the hidden word or phrase by typing their guess into the text field provided.
-      </li>
-      <li>
-        The game will indicate how many letters the player has guessed correctly, but not in the correct position, and how many letters are correctly placed.
-      </li>
-      <li>
-        If a letter is correctly placed, that letter will be filled in the grid in the corresponding position.
-      </li>
-      <li>
-        The player can continue guessing different words until they are able to guess the correct one.
-      </li>
-      <li>
-        Some versions of the game have a limited number of guesses, so the player should use them wisely.
-      </li>
-      <li>
-        The game can have different levels and different themes, and some versions may include a time limit.
-      </li>
-      <li>
-        Wordle is a fun and challenging word game that will test your ability to guess words based on the letters provided. Be creative and don't be afraid to try different words and combinations of letters to find the correct answer.
-      </li>
-    </ol>
+  <p>
+    Please note that the game mechanics might differ a bit from version to version but overall the rules are quite similar.
+  </p>
 
-    <p>
-      Please note that the game mechanics might differ a bit from version to version but overall the rules are quite similar.
-    </p>
+  <p>
+    <%- inlineLink('Check out the post with enhanced strategies', { href: '/posts/wordle-solver-2/' }) %> (and a better algorithm).
+  </p>
+<%- partial('section/close', { ...locals, kind: 'container' }) %>
 
-    <p>
-      <%- inlineLink('Check out the post with enhanced strategies', { href: '/posts/wordle-solver-2/' }) %> (and a better algorithm).
-    </p>
-  </div>
-</section>
-
-<section class="game-board content">
-  <h2>
-    Game Board
-  </h2>
+<%- partial('section/open', { ...locals, kind: 'none', sectionClass: 'game-board content', sectionTitle: 'Game Board' }) %>
   <p>
     Update the board below so it matches your current game. Mark each letter as a near miss (🟨) or a hit (🟩).
   </p>
@@ -131,18 +122,11 @@ scripts:
     type=button>
     Clear
   </button>
-</section>
+<%- partial('section/close', { ...locals, kind: 'none' }) %>
 
-<section class="content">
-  <h2>Potential Solutions</h2>
-  <p>Results: <span id="results-count">-</span></p>
-  <div class="p" id="options"></div>
-</section>
+<%- partial('results', { ...locals,
+  resultsTitle: 'Potential Solutions',
+  containerId: 'options',
+}) %>
 
-<toast-notification>
-  <div class="container">
-    <div class="nbar">
-      <span>✔️</span> Copied to clipboard
-    </div>
-  </div>
-</toast-notification>
+<%- partial('toast', { ...locals, message: 'Copied to clipboard' }) %>

--- a/src/templates/posts/yahtzee.ejs
+++ b/src/templates/posts/yahtzee.ejs
@@ -13,180 +13,171 @@ scripts:
   - 'posts/yahtzee'
 ---
 
-<section>
-  <div class="content">
-    <p>
-      I play a Yahtzee knock off on my phone, and it is clearly making adjustments because there are levels of difficulty. I like creating games (check out <%- inlineLink('minesweeper', { href: '/posts/minesweeper/' }); %>) and this one seemed like a fun challenge. It’s a dice game, and my focus was on getting the logic down. So, enjoy!
-    </p>
-    <p>
-      According to <%- inlineLink("Wikipedia", { href: "https://en.wikipedia.org/wiki/Yahtzee" }); %>, Yahtzee is owned by <%- inlineLink("Hasbro", { href: "https://shop.hasbro.com/en-us" }); %> and they have an
-      <%- inlineLink("Android app", { href: "https://play.google.com/store/apps/details?id=com.scopely.yux&hl=en_US&gl=US" }); %> and an
-      <%- inlineLink("iOS app", { href: "https://apps.apple.com/us/app/yahtzee-with-buddies-dice/id1206967173" }); %>. Check out a higher quality gaming experience there.
-    </p>
-  </div>
-</section>
+<%- partial('section/open', { ...locals }) %>
+  <p>
+    I play a Yahtzee knock off on my phone, and it is clearly making adjustments because there are levels of difficulty. I like creating games (check out <%- inlineLink('minesweeper', { href: '/posts/minesweeper/' }); %>) and this one seemed like a fun challenge. It’s a dice game, and my focus was on getting the logic down. So, enjoy!
+  </p>
+  <p>
+    According to <%- inlineLink("Wikipedia", { href: "https://en.wikipedia.org/wiki/Yahtzee" }); %>, Yahtzee is owned by <%- inlineLink("Hasbro", { href: "https://shop.hasbro.com/en-us" }); %> and they have an
+    <%- inlineLink("Android app", { href: "https://play.google.com/store/apps/details?id=com.scopely.yux&hl=en_US&gl=US" }); %> and an
+    <%- inlineLink("iOS app", { href: "https://apps.apple.com/us/app/yahtzee-with-buddies-dice/id1206967173" }); %>. Check out a higher quality gaming experience there.
+  </p>
+<%- partial('section/close', { ...locals }) %>
 
-<section>
-  <div class="content">
-    <h2>
-      How to play
-    </h2>
-    <p>
-      Yahtzee is a dice game played with five six-sided dice. The objective of the game is to score points by rolling certain combinations of the dice. The game is played with a scorecard, with a separate section for each combination.
-    </p>
+<%- partial('section/open', { ...locals, sectionTitle: 'How to play' }) %>
+  <p>
+    Yahtzee is a dice game played with five six-sided dice. The objective of the game is to score points by rolling certain combinations of the dice. The game is played with a scorecard, with a separate section for each combination.
+  </p>
 
-    <ol>
-      <li>
-        The first step is to roll all five dice. You can roll them as many times as you want, but you must set aside at least one die after each roll. This means that you cannot roll all five dice again after the first roll.
-      </li>
-      <li>
-        After the first roll, you can set aside any dice that you want to keep and roll the remaining dice again.
-      </li>
-      <li>
-        After the second roll, you must again set aside at least one die and you can roll the remaining dice again, if any.
-      </li>
-      <li>
-        After the third roll, you must set aside any remaining dice and cannot roll again.
-      </li>
-      <li>
-        After the third roll, you must choose one of the sections on the scorecard to fill in with your roll. For example, you might score your roll as "3 of a kind" if you have rolled three dice with the same number. Each combination can only be filled once in the game, so choose wisely.
-      </li>
-      <li>
-        Once you have filled in a section on the scorecard, your turn is over, and it's the next player's turn.
-      </li>
-      <li>
-        The game ends when all thirteen sections of the scorecard have been filled in.
-      </li>
-      <li>
-        The player with the highest total score at the end of the game wins.
-      </li>
-    </ol>
+  <ol>
+    <li>
+      The first step is to roll all five dice. You can roll them as many times as you want, but you must set aside at least one die after each roll. This means that you cannot roll all five dice again after the first roll.
+    </li>
+    <li>
+      After the first roll, you can set aside any dice that you want to keep and roll the remaining dice again.
+    </li>
+    <li>
+      After the second roll, you must again set aside at least one die and you can roll the remaining dice again, if any.
+    </li>
+    <li>
+      After the third roll, you must set aside any remaining dice and cannot roll again.
+    </li>
+    <li>
+      After the third roll, you must choose one of the sections on the scorecard to fill in with your roll. For example, you might score your roll as "3 of a kind" if you have rolled three dice with the same number. Each combination can only be filled once in the game, so choose wisely.
+    </li>
+    <li>
+      Once you have filled in a section on the scorecard, your turn is over, and it's the next player's turn.
+    </li>
+    <li>
+      The game ends when all thirteen sections of the scorecard have been filled in.
+    </li>
+    <li>
+      The player with the highest total score at the end of the game wins.
+    </li>
+  </ol>
 
-    <p>
-      Some possible combinations are:
-    </p>
+  <p>
+    Some possible combinations are:
+  </p>
 
-    <ul class="default">
-      <li>
-        3 of a kind: Sum of all the dice if three of them have the same value.
-      </li>
-      <li>
-        4 of a kind: Sum of all the dice if four of them have the same value.
-      </li>
-      <li>
-        Small Straight: 30 points if a player rolls 1-2-3-4-5 or 2-3-4-5-6 in any order.
-      </li>
-      <li>
-        Large Straight: 40 points if a player rolls 1-2-3-4-5 or 2-3-4-5-6 in order.
-      </li>
-      <li>
-        Full House: 25 points, if a player rolls two of one number, three of another number.
-      </li>
-      <li>
-        Yahtzee: 50 points, if all five dice have the same value`
-      </li>
-      <li>
-        Chance: Sum of all the dice`
-      </li>
-      <li>
-        Bonus: Extra 35 points if the single totals are greater than 62`
-      </li>
-    </ul>
+  <ul class="default">
+    <li>
+      3 of a kind: Sum of all the dice if three of them have the same value.
+    </li>
+    <li>
+      4 of a kind: Sum of all the dice if four of them have the same value.
+    </li>
+    <li>
+      Small Straight: 30 points if a player rolls 1-2-3-4-5 or 2-3-4-5-6 in any order.
+    </li>
+    <li>
+      Large Straight: 40 points if a player rolls 1-2-3-4-5 or 2-3-4-5-6 in order.
+    </li>
+    <li>
+      Full House: 25 points, if a player rolls two of one number, three of another number.
+    </li>
+    <li>
+      Yahtzee: 50 points, if all five dice have the same value`
+    </li>
+    <li>
+      Chance: Sum of all the dice`
+    </li>
+    <li>
+      Bonus: Extra 35 points if the single totals are greater than 62`
+    </li>
+  </ul>
 
-    <p>
-      Scoring combination are many and different based on the version of the game.
-    </p>
+  <p>
+    Scoring combination are many and different based on the version of the game.
+  </p>
 
-    <p>
-      A score over 200 is considered good and above 250 is considered very good. However, it really depends on the competitive level of the players and the scoring rule that been agreed upon before the game.
-    </p>
+  <p>
+    A score over 200 is considered good and above 250 is considered very good. However, it really depends on the competitive level of the players and the scoring rule that been agreed upon before the game.
+  </p>
 
-    <p>
-      It's important to remember, Yahtzee is a game of luck, so the outcome can be very different each time you play.
-    </p>
-  </div>
-</section>
+  <p>
+    It's important to remember, Yahtzee is a game of luck, so the outcome can be very different each time you play.
+  </p>
+<%- partial('section/close', { ...locals }) %>
 
-<section>
-  <div class="content">
-    <div class="game-container">
-      <button type=button id=roll data-rolls-left=3 class="button">Roll</button>
+<%- partial('section/open', { ...locals }) %>
+  <div class="game-container">
+    <button type=button id=roll data-rolls-left=3 class="button">Roll</button>
 
-      <div id=dice>
-        <% for (let i = 0; i < 5; i++) { %>
-          <button type="button" id="die-<%- i %>" value="0">0</button>
-        <% } %>
-      </div>
-
-      <div id=score-board data-rolls-left=3>
-        <div class="column">
-          <div id=ones>
-            <label>Ones</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=twos>
-            <label>Twos</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=threes>
-            <label>Threes</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=fours>
-            <label>Fours</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=fives>
-            <label>Fives</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=sixes>
-            <label>Sixes</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=kind-total>
-            <label>Total</label>
-            <div class=score>0</div>
-          </div>
-          <div id=bonus>
-            <label>Bonus</label>
-            <div class=score>0</div>
-          </div>
-        </div>
-
-        <div class="column">
-          <div id=three-kind>
-            <label>3 of a kind</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=four-kind>
-            <label>4 of a kind</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=small-straight>
-            <label>Small Straight</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=large-straight>
-            <label>Large Straight</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=full-house>
-            <label>Full House</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=wild>
-            <label>Chance</label>
-            <button type=button class=score>0</button>
-          </div>
-          <div id=yahtzee>
-            <label>Yahtzee</label>
-            <button type=button class=score>0</button>
-          </div>
-        </div>
-      </div>
-
-      <div id=total><label>Grand total:</label><span class=score>0</span></div>
+    <div id=dice>
+      <% for (let i = 0; i < 5; i++) { %>
+        <button type="button" id="die-<%- i %>" value="0">0</button>
+      <% } %>
     </div>
+
+    <div id=score-board data-rolls-left=3>
+      <div class="column">
+        <div id=ones>
+          <label>Ones</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=twos>
+          <label>Twos</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=threes>
+          <label>Threes</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=fours>
+          <label>Fours</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=fives>
+          <label>Fives</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=sixes>
+          <label>Sixes</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=kind-total>
+          <label>Total</label>
+          <div class=score>0</div>
+        </div>
+        <div id=bonus>
+          <label>Bonus</label>
+          <div class=score>0</div>
+        </div>
+      </div>
+
+      <div class="column">
+        <div id=three-kind>
+          <label>3 of a kind</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=four-kind>
+          <label>4 of a kind</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=small-straight>
+          <label>Small Straight</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=large-straight>
+          <label>Large Straight</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=full-house>
+          <label>Full House</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=wild>
+          <label>Chance</label>
+          <button type=button class=score>0</button>
+        </div>
+        <div id=yahtzee>
+          <label>Yahtzee</label>
+          <button type=button class=score>0</button>
+        </div>
+      </div>
+    </div>
+
+    <div id=total><label>Grand total:</label><span class=score>0</span></div>
   </div>
-</section>
+<%- partial('section/close', { ...locals }) %>


### PR DESCRIPTION
## Summary

Builds on top of [#65](https://github.com/briananders/briananders.com/pull/65) (the partials foundation). Sweeps through post and top-level templates and replaces the repeated section + content-wrapper + blockquote markup with calls to the partials. **Once #65 merges, this PR's diff will reduce to just the migration changes.**

This is the aggressive variant — most templates that cleanly fit the partials are migrated.

## Templates migrated (28)

| Pattern | Templates |
|---|---|
| Section wrappers | 28 templates (97+ `<section>` instances) |
| Blockquotes with cite + blockLink | 6 templates: 2d-automaton, cellular-automaton, moire-patterns, moire-pattern-colors, last-fm, polyrhythm |
| Toast notifications | wordle-solver, wordle-solver-2 |
| Results displays | wordle-solver (1), wordle-solver-2 (2) |

Top-level: `index.html.ejs` (contributions section), `about.ejs`, `drums.ejs` (intro section), `404.html.ejs`.

Posts: `2d-automaton`, `ant-life-simulator`, `blue-green`, `canvas-static`, `cellular-automaton`, `coin-flip`, `color-canvas`, `design-system`, `earth-rotating-sprite-animation`, `last-fm-scrobbles`, `last-fm`, `minesweeper`, `moire-pattern-colors`, `moire-patterns`, `music-news`, `polyrhythm`, `raining-light-effect`, `raining-paint`, `sound-frequency-slider`, `sticky-stacky`, `unique-stars`, `wordle-solver-2`, `wordle-solver`, `yahtzee`.

## Two partial fixes along the way

While migrating I discovered a collision: the page's front-matter `title` was leaking through the `{...locals}` spread, so calling `partial('section/open', {...locals})` without an explicit title rendered a duplicate page heading inside every section.

- Rename `title` -> `sectionTitle` in `section/open.ejs`
- Rename `title` -> `resultsTitle` in `results.ejs`
- Update `design-system.ejs` callsites to use the new names

This is the same kind of collision that previously forced `inputName` / `helpText` in the form partials.

## Templates left unmigrated (by design)

These don't fit the partials cleanly:

- **Article-based "tip" posts** — `my-favorite-aliases`, `my-favorite-git-aliases`, `my-git-config`, `how-to-get-rid-of-untracked-files-from-your-git-branch`, `how-to-git-merge-without-being-prompted-for-a-message`, `how-to-match-the-height-of-sibling-elements`, `quality-podcasts`. These use `<article class="content">` as the page wrapper.
- **Templates with `<header>` wrappers around headings** — `in-view-text-animation`, `interview-question`, `vertically-center-siblings`, `reverse-hover-state`, `browser-and-device-diagnostics`. Migrating would lose the semantic header element.
- **Custom wrappers / no section** — `wordscapes-solver` (uses `<div class="container section">`), `lissajous-curve`, `line-circle-rotator`, `paint`, `imdb-ratings` (uses `.movies-container`), `circle-multiplier`, `making-animations-with-squares`, `using-canvas-to-make-patterns-with-circles`, `circle-wave-illusion`.

## Verification

- `npm test` — passes (build + golden tests)
- `npm run build:golden` — clean, no errors
- Golden output for migrated pages was diffed against pre-migration HEAD. Differences fall into three buckets:
  - **0 lines** — byte-identical: 16 templates (minesweeper, canvas-static, coin-flip, color-canvas, raining-light-effect, blue-green, sound-frequency-slider, raining-paint, ant-life-simulator, unique-stars, sticky-stacky, music-news, about, drums, index, 404)
  - **Whitespace + `noWidows` typography fixes** — 7 templates, 4-16 lines each (yahtzee, polyrhythm, last-fm, moire-patterns, moire-pattern-colors, 2d-automaton, cellular-automaton). `noWidows()` adds `&nbsp;` before the last word in headings to prevent widows.
  - **Accessibility + semantic improvements** — 4 templates (wordle-solver, wordle-solver-2, last-fm-scrobbles, earth-rotating-sprite-animation): toast got `role="status"`, `aria-live="polite"`, and inner semantic spans; results count got `aria-live="polite"`; some code blocks have 2-space-less indentation inside `<pre>`.

## Not in this PR

- No `golden/` updates committed. Visual-diff baselines for the affected pages will need refreshing in a follow-up "new goldens" commit (matches the existing repo convention seen in commit `ad48ae1`).
- No SCSS or JS changes.

## Test plan

- [x] `npm run build:golden` succeeds.
- [x] `npm test` passes.
- [x] Migrated pages diff to semantically equivalent HTML (see breakdown above).
- [ ] (Reviewer) `npm start` and spot-check a handful of migrated pages in the browser — especially polyrhythm, wordle-solver, last-fm, drums, and the homepage.
- [ ] (Reviewer) Optional: regenerate `golden/` and commit as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)